### PR TITLE
Feature: GetBulk support for walks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -133,7 +133,7 @@ func unpackBulkVars(scalarCount int, entryLen int, varBinds []snmp.VarBind) ([]s
 	var entryCount = (len(varBinds) - scalarCount) / entryLen
 	var entryList = make([][]snmp.VarBind, entryCount)
 
-	if len(varBinds) <= scalarCount+entryLen || scalarCount+entryCount*entryLen != len(varBinds) {
+	if len(varBinds) < scalarCount+entryLen || scalarCount+entryCount*entryLen != len(varBinds) {
 		return nil, nil, fmt.Errorf("Invalid bulk response for %d+%d => %d vars", scalarCount, entryLen, len(varBinds))
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -193,10 +193,18 @@ func unpackBulkVars(scalarCount int, entryLen int, varBinds []snmp.VarBind) ([]s
 }
 
 func (client *Client) GetBulk(scalars []snmp.OID, entries []snmp.OID) ([]snmp.VarBind, [][]snmp.VarBind, error) {
+	var scalarLen = uint(len(scalars))
+	var entriesLen = uint(len(entries))
 	var maxRepetitions = DefaultMaxRepetitions
 
 	if client.options.MaxRepetitions != 0 {
 		maxRepetitions = client.options.MaxRepetitions
+	}
+
+	if scalarLen >= client.options.MaxVars || entriesLen >= client.options.MaxVars-scalarLen {
+		maxRepetitions = 1
+	} else if scalarLen+maxRepetitions*entriesLen > client.options.MaxVars {
+		maxRepetitions = (client.options.MaxVars - scalarLen) / entriesLen
 	}
 
 	var pdu = snmp.BulkPDU{

--- a/client/client.go
+++ b/client/client.go
@@ -59,7 +59,7 @@ func (client *Client) request(send IO) (IO, error) {
 	}
 }
 
-func (client *Client) requestGeneric(requestType snmp.PDUType, varBinds []snmp.VarBind, responseType snmp.PDUType) ([]snmp.VarBind, error) {
+func (client *Client) requestPDU(requestType snmp.PDUType, pdu snmp.PDU, responseType snmp.PDUType) ([]snmp.VarBind, error) {
 	var send = IO{
 		Addr: client.addr,
 		Packet: snmp.Packet{
@@ -67,23 +67,33 @@ func (client *Client) requestGeneric(requestType snmp.PDUType, varBinds []snmp.V
 			Community: []byte(client.options.Community),
 		},
 		PDUType: requestType,
-		PDU: snmp.GenericPDU{
-			VarBinds: varBinds,
-		},
+		PDU:     pdu,
 	}
 
-	if len(varBinds) == 0 {
-		return nil, nil
-	} else if recv, err := client.request(send); err != nil {
+	if recv, err := client.request(send); err != nil {
 		return nil, err
 	} else if recv.PDUType != responseType {
 		return nil, fmt.Errorf("Invalid %v response type, expected %v, got %v", requestType, responseType, recv.PDUType)
 	} else if responsePDU, ok := recv.PDU.(snmp.GenericPDU); !ok {
 		return nil, fmt.Errorf("Invalid %v response type, expected %v, got %v with PDU of type %T", requestType, responseType, recv.PDUType, recv.PDU)
-	} else if len(responsePDU.VarBinds) != len(varBinds) {
-		return responsePDU.VarBinds, fmt.Errorf("Invalid %v response, expected %d vars, got %v with %d vars", requestType, len(varBinds), recv.PDUType, len(responsePDU.VarBinds))
 	} else {
 		return responsePDU.VarBinds, nil
+	}
+}
+
+func (client *Client) requestGeneric(requestType snmp.PDUType, varBinds []snmp.VarBind, responseType snmp.PDUType) ([]snmp.VarBind, error) {
+	var pdu = snmp.GenericPDU{
+		VarBinds: varBinds,
+	}
+
+	if len(varBinds) == 0 {
+		return nil, nil
+	} else if varBinds, err := client.requestPDU(requestType, pdu, responseType); err != nil {
+		return nil, err
+	} else if len(varBinds) != len(varBinds) {
+		return varBinds, fmt.Errorf("Invalid %v response, expected %d vars, got %v with %d vars", requestType, len(varBinds), responseType, len(varBinds))
+	} else {
+		return varBinds, nil
 	}
 }
 
@@ -103,4 +113,64 @@ func (client *Client) Get(oids ...snmp.OID) ([]snmp.VarBind, error) {
 
 func (client *Client) GetNext(oids ...snmp.OID) ([]snmp.VarBind, error) {
 	return client.requestGeneric(snmp.GetNextRequestType, makeGetVars(oids), snmp.GetResponseType)
+}
+
+func makeBulkVars(scalars []snmp.OID, entries []snmp.OID) []snmp.VarBind {
+	var varBinds = make([]snmp.VarBind, len(scalars)+len(entries))
+
+	for i, oid := range scalars {
+		varBinds[i] = snmp.MakeVarBind(oid, nil)
+	}
+	for i, oid := range entries {
+		varBinds[len(scalars)+i] = snmp.MakeVarBind(oid, nil)
+	}
+
+	return varBinds
+}
+
+func unpackBulkVars(scalarCount int, entryLen int, varBinds []snmp.VarBind) ([]snmp.VarBind, [][]snmp.VarBind, error) {
+	var scalarVars = varBinds[:scalarCount]
+	var entryCount = (len(varBinds) - scalarCount) / entryLen
+	var entryList = make([][]snmp.VarBind, entryCount)
+
+	if len(varBinds) <= scalarCount+entryLen || scalarCount+entryCount*entryLen != len(varBinds) {
+		return nil, nil, fmt.Errorf("Invalid bulk response for %d+%d => %d vars", scalarCount, entryLen, len(varBinds))
+	}
+
+	for i := 0; i < entryCount; i++ {
+		var enrtryVars = make([]snmp.VarBind, entryLen)
+
+		for j := 0; j < entryLen; j++ {
+			enrtryVars[j] = varBinds[scalarCount+i*entryLen+j]
+		}
+
+		entryList[i] = enrtryVars
+	}
+
+	return scalarVars, entryList, nil
+
+}
+
+func (client *Client) GetBulk(scalars []snmp.OID, entries []snmp.OID) ([]snmp.VarBind, [][]snmp.VarBind, error) {
+	var maxRepetitions = DefaultMaxRepetitions
+
+	if client.options.MaxRepetitions != 0 {
+		maxRepetitions = client.options.MaxRepetitions
+	}
+
+	var pdu = snmp.BulkPDU{
+		NonRepeaters:   len(scalars),
+		MaxRepetitions: int(maxRepetitions),
+		VarBinds:       makeBulkVars(scalars, entries),
+	}
+
+	if len(pdu.VarBinds) == 0 {
+		return nil, nil, nil
+	}
+
+	if varBinds, err := client.requestPDU(snmp.GetBulkRequestType, pdu, snmp.GetResponseType); err != nil {
+		return nil, nil, err
+	} else {
+		return unpackBulkVars(len(scalars), len(entries), varBinds)
+	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -174,7 +174,7 @@ func unpackBulkVars(scalarCount int, entryLen int, varBinds []snmp.VarBind) ([]s
 	var entryCount = (len(varBinds) - scalarCount) / entryLen
 	var entryList = make([][]snmp.VarBind, entryCount)
 
-	if len(varBinds) < scalarCount+entryLen || scalarCount+entryCount*entryLen != len(varBinds) {
+	if len(varBinds) < scalarCount+entryLen {
 		return nil, nil, fmt.Errorf("Invalid bulk response for %d+%d => %d vars", scalarCount, entryLen, len(varBinds))
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -95,7 +95,7 @@ func TestGetSendError(t *testing.T) {
 				Community: []byte("public"),
 			},
 			PDUType: snmp.GetRequestType,
-			PDU: snmp.PDU{
+			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, nil),
 				},
@@ -121,7 +121,7 @@ func TestGetRecvWrongAddr(t *testing.T) {
 				Community: []byte("public"),
 			},
 			PDUType: snmp.GetRequestType,
-			PDU: snmp.PDU{
+			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, nil),
 				},
@@ -133,7 +133,7 @@ func TestGetRecvWrongAddr(t *testing.T) {
 				Community: []byte("public"),
 			},
 			PDUType: snmp.GetResponseType,
-			PDU: snmp.PDU{
+			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, 1),
 				},
@@ -161,7 +161,7 @@ func TestGetRecvWrongCommunity(t *testing.T) {
 				Community: []byte("public"),
 			},
 			PDUType: snmp.GetRequestType,
-			PDU: snmp.PDU{
+			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, nil),
 				},
@@ -173,7 +173,7 @@ func TestGetRecvWrongCommunity(t *testing.T) {
 				Community: []byte("not-public"),
 			},
 			PDUType: snmp.GetResponseType,
-			PDU: snmp.PDU{
+			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, 1),
 				},

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -268,6 +268,9 @@ func TestGetRequestGetBulk(t *testing.T) {
 	}
 
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		client.options.MaxVars = 20
+		client.options.MaxRepetitions = 5
+
 		transport.On("GetBulkRequest", IO{
 			Addr: testAddr("test"),
 			Packet: snmp.Packet{
@@ -277,7 +280,7 @@ func TestGetRequestGetBulk(t *testing.T) {
 			PDUType: snmp.GetBulkRequestType,
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
-				MaxRepetitions: int(DefaultMaxRepetitions),
+				MaxRepetitions: 5,
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, nil),
 					snmp.MakeVarBind(entryOIDs[0], nil),
@@ -329,6 +332,9 @@ func TestGetRequestGetBulkOne(t *testing.T) {
 	}
 
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		client.options.MaxVars = 20
+		client.options.MaxRepetitions = 5
+
 		transport.On("GetBulkRequest", IO{
 			Addr: testAddr("test"),
 			Packet: snmp.Packet{
@@ -338,7 +344,7 @@ func TestGetRequestGetBulkOne(t *testing.T) {
 			PDUType: snmp.GetBulkRequestType,
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
-				MaxRepetitions: int(DefaultMaxRepetitions),
+				MaxRepetitions: 5,
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, nil),
 					snmp.MakeVarBind(entryOIDs[0], nil),
@@ -384,6 +390,9 @@ func TestGetRequestGetBulkShort(t *testing.T) {
 	}
 
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		client.options.MaxVars = 20
+		client.options.MaxRepetitions = 5
+
 		transport.On("GetBulkRequest", IO{
 			Addr: testAddr("test"),
 			Packet: snmp.Packet{
@@ -393,7 +402,7 @@ func TestGetRequestGetBulkShort(t *testing.T) {
 			PDUType: snmp.GetBulkRequestType,
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
-				MaxRepetitions: int(DefaultMaxRepetitions),
+				MaxRepetitions: 5,
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, nil),
 					snmp.MakeVarBind(entryOIDs[0], nil),
@@ -428,6 +437,9 @@ func TestGetRequestGetBulkOdd(t *testing.T) {
 	}
 
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		client.options.MaxVars = 5
+		client.options.MaxRepetitions = 5
+
 		transport.On("GetBulkRequest", IO{
 			Addr: testAddr("test"),
 			Packet: snmp.Packet{
@@ -437,7 +449,7 @@ func TestGetRequestGetBulkOdd(t *testing.T) {
 			PDUType: snmp.GetBulkRequestType,
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
-				MaxRepetitions: int(DefaultMaxRepetitions),
+				MaxRepetitions: 2,
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, nil),
 					snmp.MakeVarBind(entryOIDs[0], nil),

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -260,6 +260,29 @@ func TestGetNothing(t *testing.T) {
 	})
 }
 
+func TestGetBulkMaxRepetitions(t *testing.T) {
+	var tests = []struct {
+		options Options
+		scalars uint
+		entries uint
+		result  int
+	}{
+		{options: Options{MaxVars: 10, MaxRepetitions: 10}, scalars: 0, entries: 1, result: 10},
+		{options: Options{MaxVars: 10, MaxRepetitions: 10}, scalars: 0, entries: 5, result: 2},
+		{options: Options{MaxVars: 10, MaxRepetitions: 10}, scalars: 0, entries: 6, result: 1},
+		{options: Options{MaxVars: 10, MaxRepetitions: 10}, scalars: 0, entries: 10, result: 1},
+		{options: Options{MaxVars: 10, MaxRepetitions: 10}, scalars: 0, entries: 11, result: 1},
+		{options: Options{MaxVars: 10, MaxRepetitions: 10}, scalars: 5, entries: 5, result: 1},
+		{options: Options{MaxVars: 100, MaxRepetitions: 10}, scalars: 0, entries: 5, result: 10},
+	}
+
+	for _, test := range tests {
+		var client = Client{options: test.options}
+
+		assert.Equalf(t, test.result, int(client.getBulkMaxRepetitions(test.scalars, test.entries)), "%#v", test)
+	}
+}
+
 func TestGetRequestGetBulk(t *testing.T) {
 	var scalarOID = snmp.OID{1, 3, 6, 1, 2, 1, 1, 4}
 	var entryOIDs = []snmp.OID{

--- a/client/engine.go
+++ b/client/engine.go
@@ -75,10 +75,17 @@ func (engine *Engine) receiver() {
 
 	for {
 		if recv, err := engine.transport.Recv(); err != nil {
-			engine.log.Errorf("Recv: %v", err)
+			if protocolErr, ok := err.(ProtocolError); ok {
+				engine.log.Warnf("Recv: %v", protocolErr)
 
-			engine.recvErr = err
-			return
+				continue
+			} else {
+				engine.log.Errorf("Recv: %v", err)
+
+				engine.recvErr = err
+
+				return
+			}
 		} else {
 			engine.log.Debugf("Recv: %#v", recv)
 

--- a/client/options.go
+++ b/client/options.go
@@ -10,7 +10,7 @@ const (
 	SNMPVersion           = snmp.SNMPv2c
 	DefaultTimeout        = 1 * time.Second
 	DefaultRetry          = uint(3)
-	DefaultMaxVars        = uint(10)
+	DefaultMaxVars        = uint(50)
 	DefaultMaxRepetitions = uint(10)
 )
 

--- a/client/options.go
+++ b/client/options.go
@@ -11,7 +11,7 @@ const (
 	DefaultTimeout        = 1 * time.Second
 	DefaultRetry          = uint(3)
 	DefaultMaxVars        = uint(50)
-	DefaultMaxRepetitions = uint(10)
+	DefaultMaxRepetitions = uint(20)
 )
 
 type Options struct {

--- a/client/options.go
+++ b/client/options.go
@@ -27,7 +27,7 @@ type Options struct {
 func (options *Options) InitFlags() {
 	flag.StringVar(&options.Community, "snmp-community", "public", "Default SNMP community")
 	flag.DurationVar(&options.Timeout, "snmp-timeout", DefaultTimeout, "SNMP request timeout")
-	flag.UintVar(&options.Retry, "snmp-retry", 0, "SNMP request retry")
+	flag.UintVar(&options.Retry, "snmp-retry", DefaultRetry, "SNMP request retry")
 	flag.UintVar(&options.UDP.Size, "snmp-udp-size", UDPSize, "Maximum UDP recv size")
 	flag.UintVar(&options.MaxVars, "snmp-maxvars", DefaultMaxVars, "Maximum request VarBinds")
 	flag.UintVar(&options.MaxRepetitions, "snmp-maxrepetitions", DefaultMaxRepetitions, "Maximum repetitions for GetBulk")

--- a/client/options.go
+++ b/client/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	UDP            UDPOptions
 	MaxVars        uint
 	MaxRepetitions uint
+	NoBulk         bool
 }
 
 func (options *Options) InitFlags() {
@@ -30,4 +31,5 @@ func (options *Options) InitFlags() {
 	flag.UintVar(&options.UDP.Size, "snmp-udp-size", UDPSize, "Maximum UDP recv size")
 	flag.UintVar(&options.MaxVars, "snmp-maxvars", DefaultMaxVars, "Maximum request VarBinds")
 	flag.UintVar(&options.MaxRepetitions, "snmp-maxrepetitions", DefaultMaxRepetitions, "Maximum repetitions for GetBulk")
+	flag.BoolVar(&options.NoBulk, "snmp-nobulk", false, "Do not use GetBulk requests")
 }

--- a/client/options.go
+++ b/client/options.go
@@ -7,18 +7,20 @@ import (
 )
 
 const (
-	SNMPVersion    = snmp.SNMPv2c
-	DefaultTimeout = 1 * time.Second
-	DefaultRetry   = uint(3)
-	DefaultMaxVars = uint(10)
+	SNMPVersion           = snmp.SNMPv2c
+	DefaultTimeout        = 1 * time.Second
+	DefaultRetry          = uint(3)
+	DefaultMaxVars        = uint(10)
+	DefaultMaxRepetitions = uint(10)
 )
 
 type Options struct {
-	Community string
-	Timeout   time.Duration
-	Retry     uint
-	UDP       UDPOptions
-	MaxVars   uint
+	Community      string
+	Timeout        time.Duration
+	Retry          uint
+	UDP            UDPOptions
+	MaxVars        uint
+	MaxRepetitions uint
 }
 
 func (options *Options) InitFlags() {
@@ -27,4 +29,5 @@ func (options *Options) InitFlags() {
 	flag.UintVar(&options.Retry, "snmp-retry", 0, "SNMP request retry")
 	flag.UintVar(&options.UDP.Size, "snmp-udp-size", UDPSize, "Maximum UDP recv size")
 	flag.UintVar(&options.MaxVars, "snmp-maxvars", DefaultMaxVars, "Maximum request VarBinds")
+	flag.UintVar(&options.MaxRepetitions, "snmp-maxrepetitions", DefaultMaxRepetitions, "Maximum repetitions for GetBulk")
 }

--- a/client/transport.go
+++ b/client/transport.go
@@ -29,7 +29,7 @@ type IO struct {
 
 func (io IO) key() ioKey {
 	return ioKey{
-		id:        io.PDU.RequestID,
+		id:        io.PDU.GetRequestID(),
 		community: string(io.Packet.Community),
 		addr:      io.Addr.String(),
 	}

--- a/client/transport.go
+++ b/client/transport.go
@@ -37,7 +37,20 @@ func (io IO) key() ioKey {
 
 type Transport interface {
 	Resolve(addr string) (net.Addr, error)
+
+	// Returns ProtocolError in case of soft failures
 	Send(IO) error
+
+	// Returns ProtocolError in case of soft failures
 	Recv() (IO, error)
 	Close() error
+}
+
+// soft application-layer errors, transport itself is still working
+type ProtocolError struct {
+	err error
+}
+
+func (err ProtocolError) Error() string {
+	return err.err.Error()
 }

--- a/client/transport_test.go
+++ b/client/transport_test.go
@@ -38,9 +38,10 @@ func (transport *testTransport) Resolve(addr string) (net.Addr, error) {
 }
 
 func (transport *testTransport) Send(io IO) error {
-	var requestID = io.PDU.RequestID
+	var requestID = io.PDU.GetRequestID()
 
-	io.PDU.RequestID = 0
+	// override requestID to 0 for assert.Equal() comparison
+	io.PDU.SetRequestID(0)
 
 	args := transport.MethodCalled(io.PDUType.String(), io)
 
@@ -48,7 +49,7 @@ func (transport *testTransport) Send(io IO) error {
 		// no response
 	} else {
 		recv := ret.(IO)
-		recv.PDU.RequestID = requestID
+		recv.PDU.SetRequestID(requestID)
 
 		transport.recvChan <- recv
 	}
@@ -83,7 +84,7 @@ func (transport *testTransport) mockGetTimeout(addr string, oid snmp.OID) {
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetRequestType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				snmp.MakeVarBind(oid, nil),
 			},
@@ -99,7 +100,7 @@ func (transport *testTransport) mockGet(addr string, oid snmp.OID, varBind snmp.
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetRequestType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				snmp.MakeVarBind(oid, nil),
 			},
@@ -111,7 +112,7 @@ func (transport *testTransport) mockGet(addr string, oid snmp.OID, varBind snmp.
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetResponseType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				varBind,
 			},
@@ -132,7 +133,7 @@ func (transport *testTransport) mockGetMany(addr string, oids []snmp.OID, varBin
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetRequestType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: reqVars,
 		},
 	}).Return(error(nil), IO{
@@ -142,7 +143,7 @@ func (transport *testTransport) mockGetMany(addr string, oids []snmp.OID, varBin
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetResponseType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: varBinds,
 		},
 	})
@@ -156,7 +157,7 @@ func (transport *testTransport) mockGetNext(addr string, oid snmp.OID, varBind s
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetNextRequestType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				snmp.MakeVarBind(oid, nil),
 			},
@@ -168,7 +169,7 @@ func (transport *testTransport) mockGetNext(addr string, oid snmp.OID, varBind s
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetResponseType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				varBind,
 			},
@@ -189,7 +190,7 @@ func (transport *testTransport) mockGetNextMulti(addr string, oids []snmp.OID, v
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetNextRequestType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: requestVars,
 		},
 	}).Return(error(nil), IO{
@@ -199,7 +200,7 @@ func (transport *testTransport) mockGetNextMulti(addr string, oids []snmp.OID, v
 			Community: []byte("public"),
 		},
 		PDUType: snmp.GetResponseType,
-		PDU: snmp.PDU{
+		PDU: snmp.GenericPDU{
 			VarBinds: varBinds,
 		},
 	})

--- a/client/udp.go
+++ b/client/udp.go
@@ -8,7 +8,7 @@ import (
 )
 
 const UDPPort = "161"
-const UDPSize uint = 1500
+const UDPSize uint = 64 * 1024
 
 type UDPOptions struct {
 	Size uint

--- a/client/udp_test.go
+++ b/client/udp_test.go
@@ -49,8 +49,8 @@ func (testServer *testServer) get(oid snmp.OID) (snmp.VarBind, error) {
 	return varBind, nil
 }
 
-func (testServer *testServer) handleGet(pdu snmp.PDU) (snmp.PDU, error) {
-	var response = snmp.PDU{
+func (testServer *testServer) handleGet(pdu snmp.GenericPDU) (snmp.PDU, error) {
+	var response = snmp.GenericPDU{
 		RequestID: pdu.RequestID,
 		VarBinds:  make([]snmp.VarBind, len(pdu.VarBinds)),
 	}
@@ -78,7 +78,7 @@ func (testServer *testServer) handle(recv IO) (send IO, err error) {
 	switch recv.PDUType {
 	case snmp.GetRequestType:
 		send.PDUType = snmp.GetResponseType
-		send.PDU, err = testServer.handleGet(recv.PDU)
+		send.PDU, err = testServer.handleGet(recv.PDU.(snmp.GenericPDU))
 	default:
 		return send, fmt.Errorf("Invalid request PDU type: %v", recv.PDUType)
 	}

--- a/client/walk.go
+++ b/client/walk.go
@@ -50,7 +50,7 @@ func (client *Client) walkNext(oids ...snmp.OID) ([]snmp.VarBind, error) {
 // Exception: walking without any entry OIDs will walk the scalar OIDs exactly once.
 //
 // Splits into multiple requests if the number of OIDs exceeds options.MaxVars.
-func (client *Client) Walk(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
+func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
 	var rootOIDs = make([]snmp.OID, len(scalars)+len(entries))
 	var walkOIDs = make([]snmp.OID, len(scalars)+len(entries))
 	var entryOffset = len(scalars)
@@ -118,8 +118,8 @@ func (client *Client) Walk(scalars []snmp.OID, entries []snmp.OID, walkFunc func
 	return nil
 }
 
-func (client *Client) WalkTable(entries []snmp.OID, walkFunc func(entries []snmp.VarBind) error) error {
-	return client.Walk(nil, entries, func(scalars []snmp.VarBind, entries []snmp.VarBind) error {
+func (client *Client) Walk(oids []snmp.OID, walkFunc func(varBinds []snmp.VarBind) error) error {
+	return client.WalkWithScalars(nil, oids, func(scalars []snmp.VarBind, entries []snmp.VarBind) error {
 		return walkFunc(entries)
 	})
 }

--- a/client/walk.go
+++ b/client/walk.go
@@ -4,31 +4,44 @@ import (
 	"github.com/qmsk/snmpbot/snmp"
 )
 
-// split into multiple GetNext requests of options.MaxVars
+// Split request OIDs into multiple GetNext requests of options.MaxVars each.
+//
+// Override response varbinds outside of rootOIDs with snmp.EndOfMibViewValue
 //
 // TODO: automatically handle snmp.TooBigError?
-func (client *Client) walkNext(oids ...snmp.OID) ([]snmp.VarBind, error) {
+func (client *Client) WalkNext(rootOIDs []snmp.OID, walkOIDs []snmp.OID) ([]snmp.VarBind, error) {
 	var maxVars = DefaultMaxVars
-	var retVars = make([]snmp.VarBind, len(oids))
+	var retVars = make([]snmp.VarBind, len(walkOIDs))
 	var retLen = uint(0)
 
 	if client.options.MaxVars > 0 {
 		maxVars = client.options.MaxVars
 	}
 
-	for retLen < uint(len(oids)) {
+	for retLen < uint(len(walkOIDs)) {
+		var reqOffset = retLen
 		var reqOIDs = make([]snmp.OID, maxVars)
 		var reqLen = uint(0)
 
-		for retLen+reqLen < uint(len(oids)) && reqLen < maxVars {
-			reqOIDs[reqLen] = oids[retLen+reqLen]
+		for retLen+reqLen < uint(len(walkOIDs)) && reqLen < maxVars {
+			reqOIDs[reqLen] = walkOIDs[reqOffset+reqLen]
 			reqLen++
 		}
 
-		if getVars, err := client.GetNext(reqOIDs[:reqLen]...); err != nil {
+		if varBinds, err := client.GetNext(reqOIDs[:reqLen]...); err != nil {
 			return nil, err
 		} else {
-			for _, varBind := range getVars {
+			for i, varBind := range varBinds {
+				var oid = varBind.OID()
+				var rootOID = rootOIDs[reqOffset+uint(i)]
+
+				if oid.Equals(reqOIDs[i]) || rootOID.Index(oid) == nil {
+					// not making progress, or walked out of tree
+					varBinds[i] = snmp.MakeVarBind(rootOID, snmp.EndOfMibViewValue)
+				}
+			}
+
+			for _, varBind := range varBinds {
 				retVars[retLen] = varBind
 				retLen++
 			}
@@ -46,8 +59,7 @@ func (client *Client) walkNext(oids ...snmp.OID) ([]snmp.VarBind, error) {
 // Only returns VarBinds that are within the requested OID prefixes.
 // Any response VarBind outside of the requested tree is substituited with a snmp.EndOfMibView error value.
 //
-// Returns once all entry varBinds are outside of the requested OIDs.
-// Exception: walking without any entry OIDs will walk the scalar OIDs exactly once.
+// Returns if none of the entry varBinds are within the requested OIDs.
 //
 // Splits into multiple requests if the number of OIDs exceeds options.MaxVars.
 func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
@@ -64,12 +76,9 @@ func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, wa
 		walkOIDs[entryOffset+i] = oid
 	}
 
-	// count scalar vars that we have walked
-	var scalarCount = 0
-
 	for {
 		// request splitting
-		varBinds, err := client.walkNext(walkOIDs...)
+		varBinds, err := client.WalkNext(rootOIDs, walkOIDs)
 		if err != nil {
 			return err
 		}
@@ -85,9 +94,6 @@ func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, wa
 
 			if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
 				// explicit SNMPv2 break
-			} else if oid.Equals(walkOIDs[i]) || rootOIDs[i].Index(oid) == nil {
-				// not making progress, or walked out of tree
-				varBind = snmp.MakeVarBind(rootOIDs[i], snmp.EndOfMibViewValue)
 			} else if i >= len(scalars) {
 				// making progress on entry objects
 				entryCount++
@@ -101,7 +107,7 @@ func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, wa
 			}
 		}
 
-		if entryCount > 0 || (scalarCount == 0 && len(entries) == 0) {
+		if entryCount > 0 {
 			if err := walkFunc(scalarVars, entryVars); err != nil {
 				return err
 			}
@@ -111,8 +117,6 @@ func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, wa
 			// not making any progress
 			break
 		}
-
-		scalarCount++
 	}
 
 	return nil

--- a/client/walk.go
+++ b/client/walk.go
@@ -4,9 +4,44 @@ import (
 	"github.com/qmsk/snmpbot/snmp"
 )
 
+// split into multipl GetNext requests of options.MaxVars
+//
+// TODO: automatically handle snmp.TooBigError?
+func (client *Client) walkNext(oids ...snmp.OID) ([]snmp.VarBind, error) {
+	var maxVars = DefaultMaxVars
+	var retVars = make([]snmp.VarBind, len(oids))
+	var retLen = uint(0)
+
+	if client.options.MaxVars > 0 {
+		maxVars = client.options.MaxVars
+	}
+
+	for retLen < uint(len(oids)) {
+		var reqOIDs = make([]snmp.OID, maxVars)
+		var reqLen = uint(0)
+
+		for retLen+reqLen < uint(len(oids)) && reqLen < maxVars {
+			reqOIDs[reqLen] = oids[retLen+reqLen]
+			reqLen++
+		}
+
+		if getVars, err := client.GetNext(reqOIDs[:reqLen]...); err != nil {
+			return nil, err
+		} else {
+			for _, varBind := range getVars {
+				retVars[retLen] = varBind
+				retLen++
+			}
+		}
+	}
+
+	return retVars, nil
+}
+
 // Only walks over VarBinds that are within the requested OID prefix.
 // Any response VarBind outside of the requested tree is substituited with a snmp.EndOfMibView error
 // Stops walking once all varbinds are done
+// Splits into multiple walk requests if the number of OIDs exceeds options.MaxVars
 func (client *Client) Walk(walkFunc func(...snmp.VarBind) error, startOIDs ...snmp.OID) error {
 	var oids = make([]snmp.OID, len(startOIDs))
 
@@ -15,33 +50,35 @@ func (client *Client) Walk(walkFunc func(...snmp.VarBind) error, startOIDs ...sn
 	}
 
 	for {
-		if varBinds, err := client.GetNext(oids...); err != nil {
+		// request splitting
+		varBinds, err := client.walkNext(oids...)
+		if err != nil {
 			return err
-		} else {
-			// omit vars that walked out of the table
-			var count = 0
+		}
 
-			for i, varBind := range varBinds {
-				oid := varBind.OID()
+		// omit vars that walked out of the table
+		var count = 0
 
-				if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
-					// explicit SNMPv2 break
-					continue
-				} else if oid.Equals(oids[i]) || startOIDs[i].Index(oid) == nil {
-					// not making progress, or walked out of tree
-					varBinds[i] = snmp.MakeVarBind(oids[i], snmp.EndOfMibViewValue)
-				} else {
-					oids[i] = oid
-					count++
-				}
+		for i, varBind := range varBinds {
+			oid := varBind.OID()
+
+			if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
+				// explicit SNMPv2 break
+				continue
+			} else if oid.Equals(oids[i]) || startOIDs[i].Index(oid) == nil {
+				// not making progress, or walked out of tree
+				varBinds[i] = snmp.MakeVarBind(oids[i], snmp.EndOfMibViewValue)
+			} else {
+				oids[i] = oid
+				count++
 			}
+		}
 
-			if count == 0 {
-				// no valid responses
-				break
-			} else if err := walkFunc(varBinds...); err != nil {
-				return err
-			}
+		if count == 0 {
+			// no valid responses
+			break
+		} else if err := walkFunc(varBinds...); err != nil {
+			return err
 		}
 	}
 

--- a/client/walk.go
+++ b/client/walk.go
@@ -38,26 +38,43 @@ func (client *Client) walkNext(oids ...snmp.OID) ([]snmp.VarBind, error) {
 	return retVars, nil
 }
 
-// Only walks over VarBinds that are within the requested OID prefix.
-// Any response VarBind outside of the requested tree is substituited with a snmp.EndOfMibView error
-// Stops walking once all varbinds are done
-// Splits into multiple walk requests if the number of OIDs exceeds options.MaxVars
-func (client *Client) Walk(walkFunc func(...snmp.VarBind) error, startOIDs ...snmp.OID) error {
-	var oids = make([]snmp.OID, len(startOIDs))
+// Object/Table traversal using GetNext.
+//
+// Scalar OIDs are objects that are always fetched for every traversed row.
+// Entry OIDs are objects that are fetched based on the previous row.
+//
+// Only returns VarBinds that are within the requested OID prefixes.
+// Any response VarBind outside of the requested tree is substituited with a snmp.EndOfMibView error value.
+//
+// Returns once all entry varBinds are outside of the requested OIDs.
+// Exception: walking without any entry OIDs will walk the scalar OIDs exactly once.
+// Splits into multiple requests if the number of OIDs exceeds options.MaxVars.
+func (client *Client) Walk(scalarOIDs []snmp.OID, entryOIDs []snmp.OID, walkFunc func(...snmp.VarBind) error) error {
+	var rootOIDs = make([]snmp.OID, len(scalarOIDs)+len(entryOIDs))
+	var walkOIDs = make([]snmp.OID, len(scalarOIDs)+len(entryOIDs))
+	var entryOffset = len(scalarOIDs)
 
-	for i, oid := range startOIDs {
-		oids[i] = oid
+	for i, oid := range scalarOIDs {
+		rootOIDs[i] = oid
+		walkOIDs[i] = oid
 	}
+	for i, oid := range entryOIDs {
+		rootOIDs[entryOffset+i] = oid
+		walkOIDs[entryOffset+i] = oid
+	}
+
+	// count scalar vars that we have walked
+	var scalarCount = 0
 
 	for {
 		// request splitting
-		varBinds, err := client.walkNext(oids...)
+		varBinds, err := client.walkNext(walkOIDs...)
 		if err != nil {
 			return err
 		}
 
-		// omit vars that walked out of the table
-		var count = 0
+		// count entry vars that made progress
+		var entryCount = 0
 
 		for i, varBind := range varBinds {
 			oid := varBind.OID()
@@ -65,21 +82,28 @@ func (client *Client) Walk(walkFunc func(...snmp.VarBind) error, startOIDs ...sn
 			if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
 				// explicit SNMPv2 break
 				continue
-			} else if oid.Equals(oids[i]) || startOIDs[i].Index(oid) == nil {
+			} else if oid.Equals(walkOIDs[i]) || rootOIDs[i].Index(oid) == nil {
 				// not making progress, or walked out of tree
-				varBinds[i] = snmp.MakeVarBind(oids[i], snmp.EndOfMibViewValue)
+				varBinds[i] = snmp.MakeVarBind(rootOIDs[i], snmp.EndOfMibViewValue)
+			} else if i < entryOffset {
+				// this is a scalar object, do not walk
 			} else {
-				oids[i] = oid
-				count++
+				// walk entry objects
+				walkOIDs[i] = oid
+				entryCount++
 			}
 		}
 
-		if count == 0 {
-			// no valid responses
+		if entryCount > 0 || (scalarCount == 0 && len(entryOIDs) == 0) {
+			if err := walkFunc(varBinds...); err != nil {
+				return err
+			}
+		} else {
+			// not making any progress
 			break
-		} else if err := walkFunc(varBinds...); err != nil {
-			return err
 		}
+
+		scalarCount++
 	}
 
 	return nil

--- a/client/walk.go
+++ b/client/walk.go
@@ -136,3 +136,17 @@ func (client *Client) Walk(oids []snmp.OID, walkFunc func(varBinds []snmp.VarBin
 		return walkFunc(entries)
 	})
 }
+
+// Perform a single GetNext walk step, returning either objects underneath given oid, or EndOfMibViewValue
+func (client *Client) WalkScalars(oids []snmp.OID) ([]snmp.VarBind, error) {
+	// request splitting
+	if varBinds, err := client.GetNextSplit(oids); err != nil {
+		return nil, err
+	} else {
+		if !walkScalarVars(oids, varBinds) {
+			// no scalar vars matched !?
+		}
+
+		return varBinds, err
+	}
+}

--- a/client/walk.go
+++ b/client/walk.go
@@ -4,51 +4,44 @@ import (
 	"github.com/qmsk/snmpbot/snmp"
 )
 
-// Split request OIDs into multiple GetNext requests of options.MaxVars each.
-//
-// Override response varbinds outside of rootOIDs with snmp.EndOfMibViewValue
-//
-// TODO: automatically handle snmp.TooBigError?
-func (client *Client) WalkNext(rootOIDs []snmp.OID, walkOIDs []snmp.OID) ([]snmp.VarBind, error) {
-	var maxVars = DefaultMaxVars
-	var retVars = make([]snmp.VarBind, len(walkOIDs))
-	var retLen = uint(0)
+func walkScalarVars(oids []snmp.OID, varBinds []snmp.VarBind) bool {
+	var ok = false
 
-	if client.options.MaxVars > 0 {
-		maxVars = client.options.MaxVars
-	}
+	for i, varBind := range varBinds {
+		var oid = varBind.OID()
 
-	for retLen < uint(len(walkOIDs)) {
-		var reqOffset = retLen
-		var reqOIDs = make([]snmp.OID, maxVars)
-		var reqLen = uint(0)
-
-		for retLen+reqLen < uint(len(walkOIDs)) && reqLen < maxVars {
-			reqOIDs[reqLen] = walkOIDs[reqOffset+reqLen]
-			reqLen++
-		}
-
-		if varBinds, err := client.GetNext(reqOIDs[:reqLen]...); err != nil {
-			return nil, err
+		if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
+			// explicit SNMPv2 break
+		} else if oid.Equals(oids[i]) || oids[i].Index(oid) == nil {
+			// not making progress, or walked out of tree
+			varBinds[i] = snmp.MakeVarBind(oids[i], snmp.EndOfMibViewValue)
 		} else {
-			for i, varBind := range varBinds {
-				var oid = varBind.OID()
-				var rootOID = rootOIDs[reqOffset+uint(i)]
-
-				if oid.Equals(reqOIDs[i]) || rootOID.Index(oid) == nil {
-					// not making progress, or walked out of tree
-					varBinds[i] = snmp.MakeVarBind(rootOID, snmp.EndOfMibViewValue)
-				}
-			}
-
-			for _, varBind := range varBinds {
-				retVars[retLen] = varBind
-				retLen++
-			}
+			ok = true
 		}
 	}
 
-	return retVars, nil
+	return ok
+}
+
+func walkEntryVars(rootOIDs []snmp.OID, walkOIDs []snmp.OID, varBinds []snmp.VarBind) bool {
+	var ok = false
+
+	for i, varBind := range varBinds {
+		var rootOID = rootOIDs[i]
+		var oid = varBind.OID()
+
+		if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
+			// explicit SNMPv2 break
+		} else if oid.Equals(walkOIDs[i]) || rootOID.Index(oid) == nil {
+			// not making progress, or walked out of tree
+			varBinds[i] = snmp.MakeVarBind(rootOID, snmp.EndOfMibViewValue)
+		} else {
+			walkOIDs[i] = oid
+			ok = true
+		}
+	}
+
+	return ok
 }
 
 // Object/Table traversal using GetNext.
@@ -63,63 +56,79 @@ func (client *Client) WalkNext(rootOIDs []snmp.OID, walkOIDs []snmp.OID) ([]snmp
 //
 // Splits into multiple requests if the number of OIDs exceeds options.MaxVars.
 func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
-	var rootOIDs = make([]snmp.OID, len(scalars)+len(entries))
+	if client.options.NoBulk {
+		return client.walkGetNext(scalars, entries, walkFunc)
+	} else {
+		return client.walkGetBulk(scalars, entries, walkFunc)
+	}
+}
+
+func (client *Client) walkGetNext(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
 	var walkOIDs = make([]snmp.OID, len(scalars)+len(entries))
-	var entryOffset = len(scalars)
 
 	for i, oid := range scalars {
-		rootOIDs[i] = oid
 		walkOIDs[i] = oid
 	}
 	for i, oid := range entries {
-		rootOIDs[entryOffset+i] = oid
-		walkOIDs[entryOffset+i] = oid
+		walkOIDs[len(scalars)+i] = oid
 	}
 
 	for {
 		// request splitting
-		varBinds, err := client.WalkNext(rootOIDs, walkOIDs)
+		varBinds, err := client.GetNextSplit(walkOIDs)
 		if err != nil {
 			return err
 		}
 
-		var scalarVars = make([]snmp.VarBind, len(scalars))
-		var entryVars = make([]snmp.VarBind, len(entries))
+		var scalarVars = varBinds[:len(scalars)]
+		var entryVars = varBinds[len(scalars):]
 
-		// count entry vars that made progress
-		var entryCount = 0
-
-		for i, varBind := range varBinds {
-			oid := varBind.OID()
-
-			if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
-				// explicit SNMPv2 break
-			} else if i >= len(scalars) {
-				// making progress on entry objects
-				entryCount++
-				walkOIDs[i] = oid
-			}
-
-			if i >= entryOffset {
-				entryVars[i-entryOffset] = varBind
-			} else {
-				scalarVars[i] = varBind
-			}
+		if !walkScalarVars(scalars, scalarVars) {
+			// no scalar vars matched !?
 		}
 
-		if entryCount > 0 {
-			if err := walkFunc(scalarVars, entryVars); err != nil {
-				return err
-			}
+		if !walkEntryVars(entries, walkOIDs[len(scalars):], entryVars) {
+			// did not make progress
+			return nil
 		}
 
-		if entryCount == 0 {
-			// not making any progress
-			break
+		if err := walkFunc(scalarVars, entryVars); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func (client *Client) walkGetBulk(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
+	var walkOIDs = make([]snmp.OID, len(entries))
+
+	for i, oid := range entries {
+		walkOIDs[i] = oid
+	}
+
+	for {
+		// TODO: request splitting
+		scalarVars, entryList, err := client.GetBulk(scalars, walkOIDs)
+		if err != nil {
+			return err
+		}
+
+		if !walkScalarVars(scalars, scalarVars) {
+			// no scalar vars matched !?
+		}
+
+		for _, entryVars := range entryList {
+			if !walkEntryVars(entries, walkOIDs, entryVars) {
+				// did not make progress
+				return nil
+			}
+
+			if err := walkFunc(scalarVars, entryVars); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func (client *Client) Walk(oids []snmp.OID, walkFunc func(varBinds []snmp.VarBind) error) error {

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -32,7 +32,7 @@ func testWalk(t *testing.T, client *Client, test walkTest) {
 		walkMock.On("walk", result.scalars, result.entries).Once()
 	}
 
-	if err := client.Walk(test.scalars, test.entries, func(scalars []snmp.VarBind, entries []snmp.VarBind) error {
+	if err := client.WalkWithScalars(test.scalars, test.entries, func(scalars []snmp.VarBind, entries []snmp.VarBind) error {
 		walkMock.MethodCalled("walk", scalars, entries)
 
 		return nil

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -66,7 +66,7 @@ func TestWalkTable(t *testing.T) {
 	})
 }
 
-func TestWalkScalars(t *testing.T) {
+func TestWalkScalarsOnly(t *testing.T) {
 	var oid = snmp.MustParseOID(".1.3.6.1.2.1.2.1") // IF-MIB::ifNumber
 	var varBinds = []snmp.VarBind{
 		snmp.MakeVarBind(oid.Extend(0), int(2)),
@@ -75,11 +75,10 @@ func TestWalkScalars(t *testing.T) {
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
 		transport.mockGetNext("test", oid, varBinds[0])
 
+		// nothing, because no entries
 		testWalk(t, client, walkTest{
 			scalars: []snmp.OID{oid},
-			results: []walkResult{
-				{scalars: []snmp.VarBind{varBinds[0]}},
-			},
+			results: []walkResult{},
 		})
 	})
 }

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -1,53 +1,66 @@
 package client
 
 import (
-	"fmt"
 	"github.com/qmsk/snmpbot/snmp"
 	"github.com/stretchr/testify/mock"
 	"testing"
 )
 
+type walkResult struct {
+	scalars []snmp.VarBind
+	entries []snmp.VarBind
+}
+
 type walkTest struct {
-	scalarOIDs   []snmp.OID
-	entryOIDs    []snmp.OID
-	walkVarBinds [][]snmp.VarBind
+	scalars []snmp.OID
+	entries []snmp.OID
+
+	results []walkResult
 }
 
 func testWalk(t *testing.T, client *Client, test walkTest) {
 	var walkMock mock.Mock
 	defer walkMock.AssertExpectations(t)
 
-	for _, varBinds := range test.walkVarBinds {
-		walkMock.On("walk", varBinds).Once()
+	for _, result := range test.results {
+		if result.scalars == nil {
+			result.scalars = []snmp.VarBind{}
+		}
+		if result.entries == nil {
+			result.entries = []snmp.VarBind{}
+		}
+		walkMock.On("walk", result.scalars, result.entries).Once()
 	}
 
-	if err := client.Walk(test.scalarOIDs, test.entryOIDs, func(varBinds ...snmp.VarBind) error {
-		walkMock.MethodCalled("walk", varBinds)
+	if err := client.Walk(test.scalars, test.entries, func(scalars []snmp.VarBind, entries []snmp.VarBind) error {
+		walkMock.MethodCalled("walk", scalars, entries)
 
 		return nil
 	}); err != nil {
-		t.Fatalf("Walk(%v, %v): %v", test.scalarOIDs, test.entryOIDs, err)
+		t.Fatalf("Walk(%v, %v): %v", test.scalars, test.entries, err)
 	}
 }
 
-func TestWalk(t *testing.T) {
-	var oid = snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1} // IF-MIB::ifName
+func TestWalkTable(t *testing.T) {
+	var ifName = snmp.MustParseOID(".1.3.6.1.2.1.31.1.1.1.1")            // IF-MIB::ifName
+	var ifInMulticastPkts = snmp.MustParseOID(".1.3.6.1.2.1.31.1.1.1.2") // IF-MIB::ifInMulticastPkts
+
 	var varBinds = []snmp.VarBind{
-		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 1}, []byte("if1")),
-		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 2}, []byte("if2")),
-		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 2, 1}, snmp.Counter32(0)),
+		snmp.MakeVarBind(ifName.Extend(1), []byte("if1")),
+		snmp.MakeVarBind(ifName.Extend(2), []byte("if2")),
+		snmp.MakeVarBind(ifInMulticastPkts.Extend(0), snmp.Counter32(0)),
 	}
 
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
-		transport.mockGetNext("test", oid, varBinds[0])
-		transport.mockGetNext("test", varBinds[0].OID(), varBinds[1])
-		transport.mockGetNext("test", varBinds[1].OID(), varBinds[2])
+		transport.mockGetNext("test", ifName, varBinds[0])
+		transport.mockGetNext("test", ifName.Extend(1), varBinds[1])
+		transport.mockGetNext("test", ifName.Extend(2), varBinds[2])
 
 		testWalk(t, client, walkTest{
-			entryOIDs: []snmp.OID{oid},
-			walkVarBinds: [][]snmp.VarBind{
-				[]snmp.VarBind{varBinds[0]},
-				[]snmp.VarBind{varBinds[1]},
+			entries: []snmp.OID{ifName},
+			results: []walkResult{
+				{entries: []snmp.VarBind{varBinds[0]}},
+				{entries: []snmp.VarBind{varBinds[1]}},
 			},
 		})
 	})
@@ -63,15 +76,15 @@ func TestWalkScalars(t *testing.T) {
 		transport.mockGetNext("test", oid, varBinds[0])
 
 		testWalk(t, client, walkTest{
-			scalarOIDs: []snmp.OID{oid},
-			walkVarBinds: [][]snmp.VarBind{
-				[]snmp.VarBind{varBinds[0]},
+			scalars: []snmp.OID{oid},
+			results: []walkResult{
+				{scalars: []snmp.VarBind{varBinds[0]}},
 			},
 		})
 	})
 }
 
-func TestWalkMixed(t *testing.T) {
+func TestWalk(t *testing.T) {
 	var ifNumber = snmp.MustParseOID(".1.3.6.1.2.1.2.1")                 // IF-MIB::ifNumber
 	var ifName = snmp.MustParseOID(".1.3.6.1.2.1.31.1.1.1.1")            // IF-MIB::ifName
 	var ifInMulticastPkts = snmp.MustParseOID(".1.3.6.1.2.1.31.1.1.1.2") // IF-MIB::ifInMulticastPkts
@@ -89,11 +102,11 @@ func TestWalkMixed(t *testing.T) {
 		transport.mockGetNextMulti("test", []snmp.OID{ifNumber, ifName.Extend(2)}, []snmp.VarBind{varBind, varBinds[2]})
 
 		testWalk(t, client, walkTest{
-			scalarOIDs: []snmp.OID{ifNumber},
-			entryOIDs:  []snmp.OID{ifName},
-			walkVarBinds: [][]snmp.VarBind{
-				[]snmp.VarBind{varBind, varBinds[0]},
-				[]snmp.VarBind{varBind, varBinds[1]},
+			scalars: []snmp.OID{ifNumber},
+			entries: []snmp.OID{ifName},
+			results: []walkResult{
+				{scalars: []snmp.VarBind{varBind}, entries: []snmp.VarBind{varBinds[0]}},
+				{scalars: []snmp.VarBind{varBind}, entries: []snmp.VarBind{varBinds[1]}},
 			},
 		})
 	})
@@ -113,16 +126,16 @@ func TestWalkV2(t *testing.T) {
 		transport.mockGetNext("test", varBinds[1].OID(), varBinds[2])
 
 		testWalk(t, client, walkTest{
-			entryOIDs: []snmp.OID{oid},
-			walkVarBinds: [][]snmp.VarBind{
-				[]snmp.VarBind{varBinds[0]},
-				[]snmp.VarBind{varBinds[1]},
+			entries: []snmp.OID{oid},
+			results: []walkResult{
+				{entries: []snmp.VarBind{varBinds[0]}},
+				{entries: []snmp.VarBind{varBinds[1]}},
 			},
 		})
 	})
 }
 
-func TestWalkPartial(t *testing.T) {
+func TestWalkTablePartial(t *testing.T) {
 	var oid1 = snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 1} // Q-BRIDGE-MIB::dot1qTpFdbAddress (not-accessible)
 	var oid2 = snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 2} // Q-BRIDGE-MIB::dot1qTpFdbPort
 
@@ -134,26 +147,17 @@ func TestWalkPartial(t *testing.T) {
 	}
 
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
-		var walkMock mock.Mock
-		defer walkMock.AssertExpectations(t)
-
 		transport.mockGetNextMulti("test", []snmp.OID{oid1, oid2}, []snmp.VarBind{varBinds[0], varBinds[0]})
-		walkMock.On("walk[1/2]", errBind)
-		walkMock.On("walk[2/2]", varBinds[0])
 		transport.mockGetNextMulti("test", []snmp.OID{oid1, varBinds[0].OID()}, []snmp.VarBind{varBinds[0], varBinds[1]})
-		walkMock.On("walk[1/2]", errBind)
-		walkMock.On("walk[2/2]", varBinds[1])
 		transport.mockGetNextMulti("test", []snmp.OID{oid1, varBinds[1].OID()}, []snmp.VarBind{varBinds[0], varBinds[2]})
 
-		if err := client.Walk([]snmp.OID{}, []snmp.OID{oid1, oid2}, func(varBinds ...snmp.VarBind) error {
-			for i, varBind := range varBinds {
-				walkMock.MethodCalled(fmt.Sprintf("walk[%d/%d]", i+1, len(varBinds)), varBind)
-			}
-
-			return nil
-		}); err != nil {
-			t.Fatalf("Walk(%v, %v): %v", oid1, oid2, err)
-		}
+		testWalk(t, client, walkTest{
+			entries: []snmp.OID{oid1, oid2},
+			results: []walkResult{
+				{entries: []snmp.VarBind{errBind, varBinds[0]}},
+				{entries: []snmp.VarBind{errBind, varBinds[1]}},
+			},
+		})
 	})
 }
 
@@ -201,9 +205,9 @@ func TestWalkMany(t *testing.T) {
 		})
 
 		testWalk(t, client, walkTest{
-			entryOIDs: oids,
-			walkVarBinds: [][]snmp.VarBind{
-				varBinds,
+			entries: oids,
+			results: []walkResult{
+				{entries: varBinds},
 			},
 		})
 	})

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -237,6 +237,9 @@ func TestWalkBulk(t *testing.T) {
 	}
 
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		client.options.MaxVars = 20
+		client.options.MaxRepetitions = 5
+
 		transport.On("GetBulkRequest", IO{
 			Addr: testAddr("test"),
 			Packet: snmp.Packet{
@@ -246,7 +249,7 @@ func TestWalkBulk(t *testing.T) {
 			PDUType: snmp.GetBulkRequestType,
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
-				MaxRepetitions: int(DefaultMaxRepetitions),
+				MaxRepetitions: 5,
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(ifNumber, nil),
 					snmp.MakeVarBind(ifIndex, nil),
@@ -280,7 +283,7 @@ func TestWalkBulk(t *testing.T) {
 			PDUType: snmp.GetBulkRequestType,
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
-				MaxRepetitions: int(DefaultMaxRepetitions),
+				MaxRepetitions: 5,
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(ifNumber, nil),
 					snmp.MakeVarBind(ifIndex.Extend(2), nil),

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -1,0 +1,151 @@
+package client
+
+import (
+	"fmt"
+	"github.com/qmsk/snmpbot/snmp"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestWalk(t *testing.T) {
+	var oid = snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1} // IF-MIB::ifName
+	var varBinds = []snmp.VarBind{
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 1}, []byte("if1")),
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 1}, []byte("if2")),
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 2, 1}, snmp.Counter32(0)),
+	}
+
+	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		transport.mockGetNext("test", oid, varBinds[0])
+		transport.mockGetNext("test", varBinds[0].OID(), varBinds[1])
+		transport.mockGetNext("test", varBinds[1].OID(), varBinds[2])
+
+		if err := client.Walk(func(varBinds ...snmp.VarBind) error {
+
+			return nil
+		}, oid); err != nil {
+			t.Fatalf("Walk(%v): %v", oid, err)
+		}
+	})
+}
+
+func TestWalkV2(t *testing.T) {
+	var oid = snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1} // IF-MIB::ifName
+	var varBinds = []snmp.VarBind{
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 1}, []byte("if1")),
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 1}, []byte("if2")),
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 1}, snmp.EndOfMibViewValue),
+	}
+
+	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		transport.mockGetNext("test", oid, varBinds[0])
+		transport.mockGetNext("test", varBinds[0].OID(), varBinds[1])
+		transport.mockGetNext("test", varBinds[1].OID(), varBinds[2])
+
+		if err := client.Walk(func(varBinds ...snmp.VarBind) error {
+
+			return nil
+		}, oid); err != nil {
+			t.Fatalf("Walk(%v): %v", oid, err)
+		}
+	})
+}
+
+func TestWalkPartial(t *testing.T) {
+	var oid1 = snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 1} // Q-BRIDGE-MIB::dot1qTpFdbAddress (not-accessible)
+	var oid2 = snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 2} // Q-BRIDGE-MIB::dot1qTpFdbPort
+
+	var errBind = snmp.MakeVarBind(oid1, snmp.EndOfMibViewValue)
+	var varBinds = []snmp.VarBind{
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 2, 1, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, int(1)),
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 2, 1, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22}, int(3)),
+		snmp.MakeVarBind(snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 3, 1, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, int(1)),
+	}
+
+	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		var walkMock mock.Mock
+		defer walkMock.AssertExpectations(t)
+
+		transport.mockGetNextMulti("test", []snmp.OID{oid1, oid2}, []snmp.VarBind{varBinds[0], varBinds[0]})
+		walkMock.On("walk[1/2]", errBind)
+		walkMock.On("walk[2/2]", varBinds[0])
+		transport.mockGetNextMulti("test", []snmp.OID{oid1, varBinds[0].OID()}, []snmp.VarBind{varBinds[0], varBinds[1]})
+		walkMock.On("walk[1/2]", errBind)
+		walkMock.On("walk[2/2]", varBinds[1])
+		transport.mockGetNextMulti("test", []snmp.OID{oid1, varBinds[1].OID()}, []snmp.VarBind{varBinds[0], varBinds[2]})
+
+		if err := client.Walk(func(varBinds ...snmp.VarBind) error {
+			for i, varBind := range varBinds {
+				walkMock.MethodCalled(fmt.Sprintf("walk[%d/%d]", i+1, len(varBinds)), varBind)
+			}
+
+			return nil
+		}, oid1, oid2); err != nil {
+			t.Fatalf("Walk(%v, %v): %v", oid1, oid2, err)
+		}
+	})
+}
+
+func TestWalkMany(t *testing.T) {
+	var oids = []snmp.OID{
+		snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 0},
+		snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 1},
+		snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 2},
+		snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 3},
+		snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 4},
+	}
+	var values = [][]byte{
+		[]byte("qmsk-snmp test 0"),
+		[]byte("qmsk-snmp test 1"),
+		[]byte("qmsk-snmp test 2"),
+		[]byte("qmsk-snmp test 3"),
+		[]byte("qmsk-snmp test 4"),
+	}
+
+	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		client.options.MaxVars = 2
+
+		transport.mockGetNextMulti("test", []snmp.OID{oids[0], oids[1]}, []snmp.VarBind{
+			snmp.MakeVarBind(oids[0].Extend(0), values[0]),
+			snmp.MakeVarBind(oids[1].Extend(0), values[1]),
+		})
+		transport.mockGetNextMulti("test", []snmp.OID{oids[2], oids[3]}, []snmp.VarBind{
+			snmp.MakeVarBind(oids[2].Extend(0), values[2]),
+			snmp.MakeVarBind(oids[3].Extend(0), values[3]),
+		})
+		transport.mockGetNextMulti("test", []snmp.OID{oids[4]}, []snmp.VarBind{
+			snmp.MakeVarBind(oids[4].Extend(0), values[4]),
+		})
+
+		transport.mockGetNextMulti("test", []snmp.OID{oids[0].Extend(0), oids[1].Extend(0)}, []snmp.VarBind{
+			snmp.MakeVarBind(oids[0].Extend(0), snmp.EndOfMibViewValue),
+			snmp.MakeVarBind(oids[1].Extend(0), snmp.EndOfMibViewValue),
+		})
+		transport.mockGetNextMulti("test", []snmp.OID{oids[2].Extend(0), oids[3].Extend(0)}, []snmp.VarBind{
+			snmp.MakeVarBind(oids[2].Extend(0), snmp.EndOfMibViewValue),
+			snmp.MakeVarBind(oids[3].Extend(0), snmp.EndOfMibViewValue),
+		})
+		transport.mockGetNextMulti("test", []snmp.OID{oids[4].Extend(0)}, []snmp.VarBind{
+			snmp.MakeVarBind(oids[4].Extend(0), snmp.EndOfMibViewValue),
+		})
+
+		var walkMock mock.Mock
+		defer walkMock.AssertExpectations(t)
+
+		walkMock.On("walk", []snmp.VarBind{
+			snmp.MakeVarBind(oids[0].Extend(0), values[0]),
+			snmp.MakeVarBind(oids[1].Extend(0), values[1]),
+			snmp.MakeVarBind(oids[2].Extend(0), values[2]),
+			snmp.MakeVarBind(oids[3].Extend(0), values[3]),
+			snmp.MakeVarBind(oids[4].Extend(0), values[4]),
+		})
+
+		if err := client.Walk(func(varBinds ...snmp.VarBind) error {
+			walkMock.MethodCalled("walk", varBinds)
+
+			return nil
+		}, oids...); err != nil {
+			t.Fatalf("Walk(%v): %v", oids, err)
+		}
+	})
+}

--- a/cmd/snmpobject/main.go
+++ b/cmd/snmpobject/main.go
@@ -24,7 +24,7 @@ func snmpobject(client *mibs.Client, id mibs.ID) error {
 		return fmt.Errorf("Not an object: %v", id)
 	}
 
-	return client.WalkObjects(func(object *mibs.Object, indexValues mibs.IndexValues, value mibs.Value, err error) error {
+	return client.WalkObjects([]*mibs.Object{object}, func(object *mibs.Object, indexValues mibs.IndexValues, value mibs.Value, err error) error {
 		if err != nil {
 			log.Printf("%v: %v", object, err)
 		} else {
@@ -32,7 +32,7 @@ func snmpobject(client *mibs.Client, id mibs.ID) error {
 		}
 
 		return nil
-	}, object)
+	})
 }
 
 func main() {

--- a/cmd/snmpprobe/main.go
+++ b/cmd/snmpprobe/main.go
@@ -23,11 +23,11 @@ func snmpprobe(client *mibs.Client, ids ...mibs.ID) error {
 		})
 	}
 
-	for _, id := range ids {
-		if ok, err := client.Probe(id); err != nil {
-			return err
-		} else {
-			fmt.Printf("%v = %v\n", id, ok)
+	if probed, err := client.Probe(ids); err != nil {
+		return err
+	} else {
+		for i, ok := range probed {
+			fmt.Printf("%v = %v\n", ids[i], ok)
 		}
 	}
 

--- a/cmd/snmpwalk/main.go
+++ b/cmd/snmpwalk/main.go
@@ -17,13 +17,13 @@ func init() {
 }
 
 func snmpwalk(client *client.Client, oids ...snmp.OID) error {
-	return client.Walk(func(varBinds ...snmp.VarBind) error {
+	return client.Walk(oids, func(varBinds []snmp.VarBind) error {
 		for _, varBind := range varBinds {
 			options.PrintVarBind(varBind)
 		}
 
 		return nil
-	}, oids...)
+	})
 }
 
 func main() {

--- a/mibs/client.go
+++ b/mibs/client.go
@@ -43,25 +43,14 @@ func (client Client) ProbeMany(ids []ID) (map[IDKey]bool, error) {
 	return probed, nil
 }
 
-// Read the value at a leaf object at instance .0
-func (client Client) GetObject(object *Object) (Value, error) {
-	if varBinds, err := client.Get(object.OID.Extend(0)); err != nil {
-		return nil, err
-	} else if value, err := object.Unpack(varBinds[0]); err != nil {
-		return nil, err
-	} else {
-		return value, nil
-	}
-}
-
-func (client Client) WalkObjects(f func(*Object, IndexValues, Value, error) error, objects ...*Object) error {
+func (client Client) WalkObjects(objects []*Object, f func(*Object, IndexValues, Value, error) error) error {
 	var oids = make([]snmp.OID, len(objects))
 
 	for i, object := range objects {
 		oids[i] = object.OID
 	}
 
-	return client.Walk(func(varBinds ...snmp.VarBind) error {
+	return client.Walk(oids, func(varBinds []snmp.VarBind) error {
 		for i, varBind := range varBinds {
 			var object = objects[i]
 			var walkErr error
@@ -82,11 +71,11 @@ func (client Client) WalkObjects(f func(*Object, IndexValues, Value, error) erro
 		}
 
 		return nil
-	}, oids...)
+	})
 }
 
 func (client Client) WalkTable(table *Table, f func(IndexValues, EntryValues) error) error {
-	return client.Walk(func(varBinds ...snmp.VarBind) error {
+	return client.Walk(table.EntryOIDs(), func(varBinds []snmp.VarBind) error {
 		if indexValues, entryValues, err := table.Unpack(varBinds); err != nil {
 			return err
 		} else if err := f(indexValues, entryValues); err != nil {
@@ -94,5 +83,5 @@ func (client Client) WalkTable(table *Table, f func(IndexValues, EntryValues) er
 		} else {
 			return nil
 		}
-	}, table.EntryOIDs()...)
+	})
 }

--- a/mibs/client.go
+++ b/mibs/client.go
@@ -18,7 +18,7 @@ func (client Client) Probe(ids []ID) ([]bool, error) {
 		oids[i] = id.OID
 	}
 
-	if varBinds, err := client.WalkNext(oids, oids); err != nil {
+	if varBinds, err := client.WalkScalars(oids); err != nil {
 		return probed, err
 	} else {
 		for i, varBind := range varBinds {

--- a/server/host.go
+++ b/server/host.go
@@ -83,16 +83,23 @@ func (host *Host) init(engine *Engine, config HostConfig) error {
 
 func (host *Host) probe(probeMIBs MIBs) error {
 	var client = mibs.Client{host.client}
+	var ids = probeMIBs.ListIDs()
+	var mibs = make(MIBs)
 
 	host.log.Infof("Probing MIBs: %v", probeMIBs)
 
-	if probed, err := client.ProbeMany(probeMIBs.ListIDs()); err != nil {
+	if probed, err := client.Probe(ids); err != nil {
 		return err
 	} else {
-		host.mibs = probeMIBs.FilterProbed(probed)
+		for i, ok := range probed {
+			if ok {
+				mibs.Add(ids[i].MIB)
+			}
+		}
 	}
 
 	// TODO: probe system::sysLocation?
+	host.mibs = mibs
 	host.online = true
 
 	return nil

--- a/server/mibs.go
+++ b/server/mibs.go
@@ -28,16 +28,8 @@ func (mibMap MIBs) ListIDs() []mibs.ID {
 	return list
 }
 
-func (mibMap MIBs) FilterProbed(probed map[mibs.IDKey]bool) MIBs {
-	var probedMibs = make(MIBs)
-
-	for id, mib := range mibMap {
-		if probed[mib.ID.Key()] {
-			probedMibs[id] = mib
-		}
-	}
-
-	return probedMibs
+func (mibMap MIBs) Add(mib *mibs.MIB) {
+	mibMap[mib.Name] = mib
 }
 
 func (mibMap MIBs) Objects() Objects {

--- a/server/query.go
+++ b/server/query.go
@@ -39,7 +39,7 @@ func (q *ObjectQuery) fail(host *Host, err error) {
 func (q *ObjectQuery) queryHost(host *Host) error {
 	if client, err := host.getClient(); err != nil {
 		return err
-	} else if err := client.WalkObjects(func(object *mibs.Object, indexValues mibs.IndexValues, value mibs.Value, err error) error {
+	} else if err := client.WalkObjects(q.Objects.List(), func(object *mibs.Object, indexValues mibs.IndexValues, value mibs.Value, err error) error {
 		q.resultChan <- ObjectResult{
 			Host:        host,
 			Object:      object,
@@ -48,7 +48,7 @@ func (q *ObjectQuery) queryHost(host *Host) error {
 			Error:       err,
 		}
 		return nil
-	}, q.Objects.List()...); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/snmp/bulk_pdu.go
+++ b/snmp/bulk_pdu.go
@@ -2,6 +2,8 @@ package snmp
 
 import (
 	"encoding/asn1"
+	"fmt"
+	"strings"
 )
 
 // Very similar to the PDU type, but the error fields are replaced by parameters
@@ -21,6 +23,21 @@ func (pdu BulkPDU) GetRequestID() int {
 }
 func (pdu BulkPDU) SetRequestID(id int) {
 	pdu.RequestID = id
+}
+
+func (pdu BulkPDU) String() string {
+	var scalars []string
+	var entries []string
+
+	for i, varBind := range pdu.VarBinds {
+		if i < pdu.NonRepeaters {
+			scalars = append(scalars, varBind.String())
+		} else {
+			entries = append(entries, varBind.String())
+		}
+	}
+
+	return fmt.Sprintf("[%v] + %dx[%v]", strings.Join(scalars, ", "), pdu.MaxRepetitions, strings.Join(entries, ", "))
 }
 
 func (pdu BulkPDU) GetError() PDUError {

--- a/snmp/bulk_pdu.go
+++ b/snmp/bulk_pdu.go
@@ -1,0 +1,31 @@
+package snmp
+
+import (
+	"encoding/asn1"
+	"fmt"
+)
+
+// Very similar to the PDU type, but the error fields are replaced by parameters
+type BulkPDU struct {
+	RequestID      int
+	NonRepeaters   int
+	MaxRepetitions int
+	VarBinds       []VarBind
+}
+
+func (pdu BulkPDU) Pack(pduType PDUType) (asn1.RawValue, error) {
+	return packSequence(asn1.ClassContextSpecific, int(pduType),
+		pdu.RequestID,
+		pdu.NonRepeaters,
+		pdu.MaxRepetitions,
+		pdu.VarBinds,
+	)
+}
+
+func (pdu *BulkPDU) Unpack(raw asn1.RawValue) error {
+	if raw.Class != asn1.ClassContextSpecific {
+		return fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
+	}
+
+	return unpack(raw, pdu)
+}

--- a/snmp/bulk_pdu.go
+++ b/snmp/bulk_pdu.go
@@ -19,6 +19,13 @@ func (pdu *BulkPDU) unpack(raw asn1.RawValue) error {
 func (pdu BulkPDU) GetRequestID() int {
 	return pdu.RequestID
 }
+func (pdu BulkPDU) SetRequestID(id int) {
+	pdu.RequestID = id
+}
+
+func (pdu BulkPDU) GetError() PDUError {
+	return PDUError{}
+}
 
 func (pdu BulkPDU) Pack(pduType PDUType) (asn1.RawValue, error) {
 	return packSequence(asn1.ClassContextSpecific, int(pduType),

--- a/snmp/bulk_pdu.go
+++ b/snmp/bulk_pdu.go
@@ -2,7 +2,6 @@ package snmp
 
 import (
 	"encoding/asn1"
-	"fmt"
 )
 
 // Very similar to the PDU type, but the error fields are replaced by parameters
@@ -13,6 +12,14 @@ type BulkPDU struct {
 	VarBinds       []VarBind
 }
 
+func (pdu *BulkPDU) unpack(raw asn1.RawValue) error {
+	return unpack(raw, pdu)
+}
+
+func (pdu BulkPDU) GetRequestID() int {
+	return pdu.RequestID
+}
+
 func (pdu BulkPDU) Pack(pduType PDUType) (asn1.RawValue, error) {
 	return packSequence(asn1.ClassContextSpecific, int(pduType),
 		pdu.RequestID,
@@ -20,12 +27,4 @@ func (pdu BulkPDU) Pack(pduType PDUType) (asn1.RawValue, error) {
 		pdu.MaxRepetitions,
 		pdu.VarBinds,
 	)
-}
-
-func (pdu *BulkPDU) Unpack(raw asn1.RawValue) error {
-	if raw.Class != asn1.ClassContextSpecific {
-		return fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
-	}
-
-	return unpack(raw, pdu)
 }

--- a/snmp/generic_pdu.go
+++ b/snmp/generic_pdu.go
@@ -1,0 +1,53 @@
+package snmp
+
+import (
+	"encoding/asn1"
+	"fmt"
+	"strings"
+)
+
+type GenericPDU struct {
+	RequestID   int
+	ErrorStatus ErrorStatus
+	ErrorIndex  int
+	VarBinds    []VarBind
+}
+
+func (pdu *GenericPDU) unpack(raw asn1.RawValue) error {
+	return unpack(raw, pdu)
+}
+
+func (pdu GenericPDU) GetRequestID() int {
+	return pdu.RequestID
+}
+
+func (pdu GenericPDU) String() string {
+	if pdu.ErrorStatus != 0 {
+		return fmt.Sprintf("!%v", pdu.ErrorStatus)
+	}
+
+	var varBinds = make([]string, len(pdu.VarBinds))
+
+	for i, varBind := range pdu.VarBinds {
+		varBinds[i] = varBind.String()
+	}
+
+	return strings.Join(varBinds, ", ")
+}
+
+func (pdu GenericPDU) ErrorVarBind() VarBind {
+	if pdu.ErrorIndex < len(pdu.VarBinds) {
+		return pdu.VarBinds[pdu.ErrorIndex]
+	} else {
+		return VarBind{}
+	}
+}
+
+func (pdu GenericPDU) Pack(pduType PDUType) (asn1.RawValue, error) {
+	return packSequence(asn1.ClassContextSpecific, int(pduType),
+		pdu.RequestID,
+		pdu.ErrorStatus,
+		pdu.ErrorIndex,
+		pdu.VarBinds,
+	)
+}

--- a/snmp/generic_pdu.go
+++ b/snmp/generic_pdu.go
@@ -20,6 +20,9 @@ func (pdu *GenericPDU) unpack(raw asn1.RawValue) error {
 func (pdu GenericPDU) GetRequestID() int {
 	return pdu.RequestID
 }
+func (pdu GenericPDU) SetRequestID(id int) {
+	pdu.RequestID = id
+}
 
 func (pdu GenericPDU) String() string {
 	if pdu.ErrorStatus != 0 {
@@ -35,11 +38,18 @@ func (pdu GenericPDU) String() string {
 	return strings.Join(varBinds, ", ")
 }
 
-func (pdu GenericPDU) ErrorVarBind() VarBind {
-	if pdu.ErrorIndex < len(pdu.VarBinds) {
-		return pdu.VarBinds[pdu.ErrorIndex]
+func (pdu GenericPDU) GetVarBind(index int) VarBind {
+	if index < len(pdu.VarBinds) {
+		return pdu.VarBinds[index]
 	} else {
 		return VarBind{}
+	}
+}
+
+func (pdu GenericPDU) GetError() PDUError {
+	return PDUError{
+		ErrorStatus: pdu.ErrorStatus,
+		VarBind:     pdu.GetVarBind(pdu.ErrorIndex),
 	}
 }
 

--- a/snmp/marshal.go
+++ b/snmp/marshal.go
@@ -49,15 +49,6 @@ func marshalSequence(cls int, tag int, values ...interface{}) ([]byte, error) {
 	}
 }
 
-func (packet Packet) Marshal() ([]byte, error) {
-	return asn1.Marshal(packet)
-}
-
-func (pdu PDU) Pack(pduType PDUType) (asn1.RawValue, error) {
-	return packSequence(asn1.ClassContextSpecific, int(pduType),
-		pdu.RequestID,
-		pdu.ErrorStatus,
-		pdu.ErrorIndex,
-		pdu.VarBinds,
-	)
+func marshal(obj interface{}) ([]byte, error) {
+	return asn1.Marshal(obj)
 }

--- a/snmp/oid.go
+++ b/snmp/oid.go
@@ -8,6 +8,15 @@ import (
 
 type OID []int
 
+// panic on ParseOID errors
+func MustParseOID(str string) OID {
+	if oid, err := ParseOID(str); err != nil {
+		panic(err)
+	} else {
+		return oid
+	}
+}
+
 func ParseOID(str string) (OID, error) {
 	if str == "" {
 		return nil, nil

--- a/snmp/packet.go
+++ b/snmp/packet.go
@@ -11,10 +11,6 @@ type Packet struct {
 	RawPDU    asn1.RawValue
 }
 
-func (packet Packet) Marshal() ([]byte, error) {
-	return marshal(packet)
-}
-
 func (packet *Packet) Unmarshal(buf []byte) error {
 	if err := unmarshal(buf, packet); err != nil {
 		return err
@@ -30,4 +26,22 @@ func (packet *Packet) Unmarshal(buf []byte) error {
 func (packet *Packet) PDUType() PDUType {
 	// assuming packet.PDU.Class == asn1.ClassContextSpecific
 	return PDUType(packet.RawPDU.Tag)
+}
+
+func (packet *Packet) UnpackPDU() (PDUType, PDU, error) {
+	return UnpackPDU(packet.RawPDU)
+}
+
+func (packet *Packet) PackPDU(pduType PDUType, pdu PDU) error {
+	if rawPDU, err := pdu.Pack(pduType); err != nil {
+		return err
+	} else {
+		packet.RawPDU = rawPDU
+	}
+
+	return nil
+}
+
+func (packet *Packet) Marshal() ([]byte, error) {
+	return marshal(*packet)
 }

--- a/snmp/packet.go
+++ b/snmp/packet.go
@@ -1,0 +1,33 @@
+package snmp
+
+import (
+	"encoding/asn1"
+	"fmt"
+)
+
+type Packet struct {
+	Version   Version
+	Community []byte
+	RawPDU    asn1.RawValue
+}
+
+func (packet Packet) Marshal() ([]byte, error) {
+	return marshal(packet)
+}
+
+func (packet *Packet) Unmarshal(buf []byte) error {
+	if err := unmarshal(buf, packet); err != nil {
+		return err
+	}
+
+	if packet.RawPDU.Class != asn1.ClassContextSpecific {
+		return fmt.Errorf("unexpected PDU: ASN.1 class %d", packet.RawPDU.Class)
+	}
+
+	return nil
+}
+
+func (packet *Packet) PDUType() PDUType {
+	// assuming packet.PDU.Class == asn1.ClassContextSpecific
+	return PDUType(packet.RawPDU.Tag)
+}

--- a/snmp/packet_test.go
+++ b/snmp/packet_test.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"encoding/asn1"
 	"encoding/hex"
 	"github.com/stretchr/testify/assert"
 	"regexp"
@@ -17,46 +18,39 @@ func decodeTestPacket(str string) []byte {
 	}
 }
 
+// prepare a VarBind for use with assert.Equal() in tests
+func testVarBind(oid OID, value interface{}) VarBind {
+	varBind := MakeVarBind(oid, value)
+
+	if varBind.RawValue.Bytes == nil {
+		varBind.RawValue.Bytes = []byte{}
+	}
+
+	if data, err := asn1.Marshal(varBind.RawValue); err != nil {
+		panic(err)
+	} else {
+		varBind.RawValue.FullBytes = data
+	}
+
+	return varBind
+}
+
 type packetTest struct {
 	bytes   []byte
 	packet  Packet
 	pduType PDUType
 	pdu     PDU
-	bulkPDU BulkPDU
-	values  []interface{} // for unmarshal
 }
 
 func testPacketMarshal(t *testing.T, test packetTest) {
-	if packedPDU, err := test.pdu.Pack(test.pduType); err != nil {
+	if err := test.packet.PackPDU(test.pduType, test.pdu); err != nil {
 		t.Fatalf("pdu.pack: %v", err)
-	} else {
-		test.packet.RawPDU = packedPDU
 	}
 
 	if bytes, err := test.packet.Marshal(); err != nil {
 		t.Fatalf("packet.marshal: %v", err)
 	} else {
 		assert.Equal(t, test.bytes, bytes)
-	}
-}
-
-func testPacketValues(t *testing.T, test packetTest, varBinds []VarBind) {
-	for i, varBind := range varBinds {
-		if i >= len(test.pdu.VarBinds) {
-			t.Errorf("extra varBind[%d]: %#v", i, varBind)
-			continue
-		}
-
-		assert.Equal(t, test.pdu.VarBinds[i].Name, varBind.Name, "VarBinds[i].Name", i)
-
-		if value, err := varBind.Value(); err != nil {
-			t.Errorf("varBind[%d].Value: %s", i, err)
-			continue
-		} else if i >= len(test.values) {
-			t.Fatalf("missing test.values for varBind[%d]", i)
-		} else {
-			assert.Equal(t, test.values[i], value, "VarBinds[i].Value", i)
-		}
 	}
 }
 
@@ -64,42 +58,31 @@ func testPacketUnmarshal(t *testing.T, test packetTest) {
 	var packet Packet
 	var pdu PDU
 
-	if err := packet.Unmarshal(test.bytes); err != nil {
-		t.Errorf("packet.unmarshal: %v", err)
+	err := packet.Unmarshal(test.bytes)
+	if err != nil {
+		t.Errorf("packet.Unmarshal: %v", err)
 		return
 	}
 
-	if err := pdu.Unpack(packet.RawPDU); err != nil {
-		t.Errorf("pdu.unpack: %v", err)
+	pduType, pdu, err := packet.UnpackPDU()
+	if err != nil {
+		t.Errorf("packet.UnpackPDU: %v", err)
 		return
 	}
 
 	assert.Equal(t, test.packet.Version, packet.Version)
 	assert.Equal(t, test.packet.Community, packet.Community)
-	assert.Equal(t, test.pduType, packet.PDUType())
-	assert.Equal(t, test.pdu.RequestID, pdu.RequestID)
-	assert.Equal(t, test.pdu.ErrorStatus, pdu.ErrorStatus)
-	assert.Equal(t, test.pdu.ErrorIndex, pdu.ErrorIndex)
-
-	testPacketValues(t, test, pdu.VarBinds)
+	assert.Equal(t, test.pduType, pduType)
+	assert.Equal(t, test.pdu, pdu)
 }
 
-func testBulkPacketMarshal(t *testing.T, test packetTest) {
-	if packedPDU, err := test.bulkPDU.Pack(test.pduType); err != nil {
-		t.Fatalf("pdu.pack: %v", err)
-	} else {
-		test.packet.RawPDU = packedPDU
-	}
-
-	if bytes, err := test.packet.Marshal(); err != nil {
-		t.Fatalf("packet.marshal: %v", err)
-	} else {
-		assert.Equal(t, test.bytes, bytes)
-	}
+func testPacket(t *testing.T, test packetTest) {
+	testPacketMarshal(t, test)
+	testPacketUnmarshal(t, test)
 }
 
-func TestPacketMarshal(t *testing.T) {
-	testPacketMarshal(t, packetTest{
+func TestPacketGetRequest(t *testing.T) {
+	testPacket(t, packetTest{
 		bytes: decodeTestPacket(`
 			30 21 											-- SEQUENCE
 			02 01 01 										-- INTEGER version
@@ -118,17 +101,17 @@ func TestPacketMarshal(t *testing.T) {
 			Community: []byte("public"),
 		},
 		pduType: GetNextRequestType,
-		pdu: PDU{
+		pdu: GenericPDU{
 			RequestID: 1337,
 			VarBinds: []VarBind{
-				MakeVarBind(OID{1, 3, 6}, nil),
+				testVarBind(OID{1, 3, 6}, nil),
 			},
 		},
 	})
 }
 
-func TestPacketUnmarshal(t *testing.T) {
-	testPacketUnmarshal(t, packetTest{
+func TestPacketGetResponse(t *testing.T) {
+	testPacket(t, packetTest{
 		bytes: decodeTestPacket(`
         30 38 02 01 01 04 06 70 75 62 6c 69 63 a2 2b 02
         04 01 7a 6d f3 02 01 00 02 01 00 30 1d 30 1b 06
@@ -140,20 +123,17 @@ func TestPacketUnmarshal(t *testing.T) {
 			Community: []byte("public"),
 		},
 		pduType: GetResponseType,
-		pdu: PDU{
+		pdu: GenericPDU{
 			RequestID: 24800755,
 			VarBinds: []VarBind{
-				MakeVarBind(OID{1, 3, 6, 1, 2, 1, 1, 5, 0}, []byte("UBNT EdgeSwitch")),
+				testVarBind(OID{1, 3, 6, 1, 2, 1, 1, 5, 0}, []byte("UBNT EdgeSwitch")),
 			},
-		},
-		values: []interface{}{
-			[]byte("UBNT EdgeSwitch"),
 		},
 	})
 }
 
-func TestPacketMarshalCounter32(t *testing.T) {
-	testPacketMarshal(t, packetTest{
+func TestPacketCounter32(t *testing.T) {
+	testPacket(t, packetTest{
 		bytes: decodeTestPacket(`
 			30 30 02 01 01 04 06 70 75 62 6c 69 63 a2 23 02
 			04 29 9e 37 ef 02 01 00 02 01 00 30 15 30 13 06
@@ -165,42 +145,17 @@ func TestPacketMarshalCounter32(t *testing.T) {
 			Community: []byte("public"),
 		},
 		pduType: GetResponseType,
-		pdu: PDU{
+		pdu: GenericPDU{
 			RequestID: 698234863,
 			VarBinds: []VarBind{
-				MakeVarBind(OID{1, 3, 6, 1, 2, 1, 2, 2, 1, 10, 1}, Counter32(2833025851)),
+				testVarBind(OID{1, 3, 6, 1, 2, 1, 2, 2, 1, 10, 1}, Counter32(2833025851)),
 			},
 		},
 	})
 }
 
-func TestPacketUnmarshalCounter32(t *testing.T) {
-	testPacketUnmarshal(t, packetTest{
-		bytes: decodeTestPacket(`
-			30 30 02 01 01 04 06 70 75 62 6c 69 63 a2 23 02
-			04 29 9e 37 ef 02 01 00 02 01 00 30 15 30 13 06
-			0a 2b 06 01 02 01 02 02 01 0a 01 41 05 00 a8 dc
-			8b 3b
-		`),
-		packet: Packet{
-			Version:   SNMPv2c,
-			Community: []byte("public"),
-		},
-		pduType: GetResponseType,
-		pdu: PDU{
-			RequestID: 698234863,
-			VarBinds: []VarBind{
-				MakeVarBind(OID{1, 3, 6, 1, 2, 1, 2, 2, 1, 10, 1}, Counter32(2833025851)),
-			},
-		},
-		values: []interface{}{
-			Counter32(2833025851),
-		},
-	})
-}
-
-func TestPacketUnmarshalNoSuchInstance(t *testing.T) {
-	testPacketUnmarshal(t, packetTest{
+func TestPacketNoSuchInstance(t *testing.T) {
+	testPacket(t, packetTest{
 		bytes: decodeTestPacket(`
 			30 29 02 01 01 04 06 70 75 62 6c 69 63 a2 1c 02
 			04 47 6b 38 88 02 01 00 02 01 00 30 0e 30 0c 06
@@ -211,19 +166,17 @@ func TestPacketUnmarshalNoSuchInstance(t *testing.T) {
 			Community: []byte("public"),
 		},
 		pduType: GetResponseType,
-		pdu: PDU{
+		pdu: GenericPDU{
 			RequestID: 1198209160,
 			VarBinds: []VarBind{
-				MakeVarBind(OID{1, 3, 6, 1, 2, 1, 1, 5, 1}, NoSuchInstanceValue),
+				testVarBind(OID{1, 3, 6, 1, 2, 1, 1, 5, 1}, NoSuchInstanceValue),
 			},
 		},
-		values: []interface{}{
-			NoSuchInstanceValue,
-		}})
+	})
 }
 
-func TestPacketMarshalGetBulk(t *testing.T) {
-	testBulkPacketMarshal(t, packetTest{
+func TestPacketGetBulk(t *testing.T) {
+	testPacket(t, packetTest{
 		bytes: decodeTestPacket(`
 			30 39 02 01 01 04 06 70 75 62 6c 69 63 a5 2c 02
 			04 2c 6a 76 19 02 01 00 02 01 0a 30 1e 30 0d 06
@@ -235,13 +188,13 @@ func TestPacketMarshalGetBulk(t *testing.T) {
 			Community: []byte("public"),
 		},
 		pduType: GetBulkRequestType,
-		bulkPDU: BulkPDU{
+		pdu: BulkPDU{
 			RequestID:      745174553,
 			NonRepeaters:   0,
 			MaxRepetitions: 10,
 			VarBinds: []VarBind{
-				MakeVarBind(MustParseOID(".1.3.6.1.2.1.2.2.1.1"), nil),
-				MakeVarBind(MustParseOID(".1.3.6.1.2.1.2.2.1.2"), nil),
+				testVarBind(MustParseOID(".1.3.6.1.2.1.2.2.1.1"), nil),
+				testVarBind(MustParseOID(".1.3.6.1.2.1.2.2.1.2"), nil),
 			},
 		},
 	})

--- a/snmp/pdu.go
+++ b/snmp/pdu.go
@@ -5,8 +5,17 @@ import (
 	"fmt"
 )
 
+type PDUError struct {
+	ErrorStatus ErrorStatus
+	VarBind     VarBind
+}
+
 type PDU interface {
 	GetRequestID() int
+	SetRequestID(int)
+
+	GetError() PDUError
+
 	Pack(PDUType) (asn1.RawValue, error)
 }
 

--- a/snmp/pdu.go
+++ b/snmp/pdu.go
@@ -1,0 +1,53 @@
+package snmp
+
+import (
+	"encoding/asn1"
+	"fmt"
+	"strings"
+)
+
+type PDU struct {
+	RequestID   int
+	ErrorStatus ErrorStatus
+	ErrorIndex  int
+	VarBinds    []VarBind
+}
+
+func (pdu PDU) String() string {
+	if pdu.ErrorStatus != 0 {
+		return fmt.Sprintf("!%v", pdu.ErrorStatus)
+	}
+
+	var varBinds = make([]string, len(pdu.VarBinds))
+
+	for i, varBind := range pdu.VarBinds {
+		varBinds[i] = varBind.String()
+	}
+
+	return strings.Join(varBinds, ", ")
+}
+
+func (pdu PDU) ErrorVarBind() VarBind {
+	if pdu.ErrorIndex < len(pdu.VarBinds) {
+		return pdu.VarBinds[pdu.ErrorIndex]
+	} else {
+		return VarBind{}
+	}
+}
+
+func (pdu PDU) Pack(pduType PDUType) (asn1.RawValue, error) {
+	return packSequence(asn1.ClassContextSpecific, int(pduType),
+		pdu.RequestID,
+		pdu.ErrorStatus,
+		pdu.ErrorIndex,
+		pdu.VarBinds,
+	)
+}
+
+func (pdu *PDU) Unpack(raw asn1.RawValue) error {
+	if raw.Class != asn1.ClassContextSpecific {
+		return fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
+	}
+
+	return unpack(raw, pdu)
+}

--- a/snmp/pdu.go
+++ b/snmp/pdu.go
@@ -3,51 +3,36 @@ package snmp
 import (
 	"encoding/asn1"
 	"fmt"
-	"strings"
 )
 
-type PDU struct {
-	RequestID   int
-	ErrorStatus ErrorStatus
-	ErrorIndex  int
-	VarBinds    []VarBind
+type PDU interface {
+	GetRequestID() int
+	Pack(PDUType) (asn1.RawValue, error)
 }
 
-func (pdu PDU) String() string {
-	if pdu.ErrorStatus != 0 {
-		return fmt.Sprintf("!%v", pdu.ErrorStatus)
-	}
+func UnpackPDU(raw asn1.RawValue) (PDUType, PDU, error) {
+	var pduType = PDUType(raw.Tag)
 
-	var varBinds = make([]string, len(pdu.VarBinds))
-
-	for i, varBind := range pdu.VarBinds {
-		varBinds[i] = varBind.String()
-	}
-
-	return strings.Join(varBinds, ", ")
-}
-
-func (pdu PDU) ErrorVarBind() VarBind {
-	if pdu.ErrorIndex < len(pdu.VarBinds) {
-		return pdu.VarBinds[pdu.ErrorIndex]
-	} else {
-		return VarBind{}
-	}
-}
-
-func (pdu PDU) Pack(pduType PDUType) (asn1.RawValue, error) {
-	return packSequence(asn1.ClassContextSpecific, int(pduType),
-		pdu.RequestID,
-		pdu.ErrorStatus,
-		pdu.ErrorIndex,
-		pdu.VarBinds,
-	)
-}
-
-func (pdu *PDU) Unpack(raw asn1.RawValue) error {
 	if raw.Class != asn1.ClassContextSpecific {
-		return fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
+		return pduType, nil, fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
 	}
 
-	return unpack(raw, pdu)
+	switch pduType {
+	case GetRequestType, GetNextRequestType, GetResponseType, SetRequestType:
+		var pdu GenericPDU
+
+		err := pdu.unpack(raw)
+
+		return pduType, pdu, err
+
+	case GetBulkRequestType:
+		var pdu BulkPDU
+
+		err := pdu.unpack(raw)
+
+		return pduType, pdu, err
+
+	default:
+		return pduType, nil, fmt.Errorf("Unknown PDUType=%v", pduType)
+	}
 }

--- a/snmp/snmp.go
+++ b/snmp/snmp.go
@@ -4,7 +4,6 @@ import (
 	"encoding/asn1"
 	"fmt"
 	"net"
-	"strings"
 	"time"
 )
 
@@ -135,41 +134,6 @@ const (
 	OpaqueType      ApplicationValueType = 4
 	Counter64Type   ApplicationValueType = 6
 )
-
-type Packet struct {
-	Version   Version
-	Community []byte
-	RawPDU    asn1.RawValue
-}
-
-type PDU struct {
-	RequestID   int
-	ErrorStatus ErrorStatus
-	ErrorIndex  int
-	VarBinds    []VarBind
-}
-
-func (pdu PDU) String() string {
-	if pdu.ErrorStatus != 0 {
-		return fmt.Sprintf("!%v", pdu.ErrorStatus)
-	}
-
-	var varBinds = make([]string, len(pdu.VarBinds))
-
-	for i, varBind := range pdu.VarBinds {
-		varBinds[i] = varBind.String()
-	}
-
-	return strings.Join(varBinds, ", ")
-}
-
-func (pdu PDU) ErrorVarBind() VarBind {
-	if pdu.ErrorIndex < len(pdu.VarBinds) {
-		return pdu.VarBinds[pdu.ErrorIndex]
-	} else {
-		return VarBind{}
-	}
-}
 
 // SNMPv1 Trap-PDU
 type TrapPDU struct {

--- a/snmp/unmarshal.go
+++ b/snmp/unmarshal.go
@@ -29,29 +29,12 @@ func unpack(raw asn1.RawValue, value interface{}) error {
 	return nil
 }
 
-func (packet *Packet) Unmarshal(buf []byte) error {
-	if _, err := ber.Unmarshal(buf, packet); err != nil {
+func unmarshal(data []byte, obj interface{}) error {
+	if _, err := ber.Unmarshal(data, obj); err != nil {
 		return err
 	} else {
-		// ignore trailing bytes
-	}
-
-	if packet.RawPDU.Class != asn1.ClassContextSpecific {
-		return fmt.Errorf("unexpected PDU: ASN.1 class %d", packet.RawPDU.Class)
+		// XXX: ignore trailing bytes
 	}
 
 	return nil
-}
-
-func (packet *Packet) PDUType() PDUType {
-	// assuming packet.PDU.Class == asn1.ClassContextSpecific
-	return PDUType(packet.RawPDU.Tag)
-}
-
-func (pdu *PDU) Unpack(raw asn1.RawValue) error {
-	if raw.Class != asn1.ClassContextSpecific {
-		return fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
-	}
-
-	return unpack(raw, pdu)
 }

--- a/snmp/varbind.go
+++ b/snmp/varbind.go
@@ -31,7 +31,9 @@ type VarBind struct {
 }
 
 func (varBind VarBind) String() string {
-	if value, err := varBind.Value(); err != nil {
+	if len(varBind.Name) == 0 {
+		return fmt.Sprintf(".")
+	} else if value, err := varBind.Value(); err != nil {
 		return fmt.Sprintf("!%v", varBind.Name)
 	} else if value != nil {
 		return fmt.Sprintf("%v=%v", varBind.Name, value)


### PR DESCRIPTION
Fixes #6

* Change the `snmp` package API to use a `type PDU interface { ... }` to support both `GenericPDU` and `BulkPDU` for send/recv
* Fix `client:Engine.receiver` to not fail the entire engine on protocol-level errors like UDP recv truncation; allow requests to timeout instead
  * Fix CLI to exit on engine errors
* Add `client:Client.GetBulk(scalars []snmp.OID, entries []snmp.OID) ([]snmp.VarBind, [][]snmp.VarBind, error)`
* Update CLI `-snmp-udp-size=65536` and `-snmp-maxvars=50` defaults to better support use of bulk requests
* Add CLI `-snmp-maxrepetitions=20` to limit the maximum number of repetitions per `GetBulk` request
  * Note that the actual maximum-repetitions value used also takes the `-snmp-maxvars` limit into account, so it also depends on how many entry OIDs are being queried
* Change `client:Client.Walk` and related APIs to support scalar+entries walks using either split `GetNext` requests or `GetBulk`
