### PR TITLE
Fix client PDU RequestID

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -66,8 +66,10 @@ func (client *Client) requestPDU(requestType snmp.PDUType, pdu snmp.PDU, respons
 			Version:   SNMPVersion,
 			Community: []byte(client.options.Community),
 		},
-		PDUType: requestType,
-		PDU:     pdu,
+		PDUMeta: snmp.PDUMeta{
+			PDUType: requestType,
+		},
+		PDU: pdu,
 	}
 
 	if recv, err := client.request(send); err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -93,7 +93,7 @@ func TestGetSendError(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, nil),
@@ -119,7 +119,7 @@ func TestGetRecvWrongAddr(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, nil),
@@ -131,7 +131,7 @@ func TestGetRecvWrongAddr(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, 1),
@@ -159,7 +159,7 @@ func TestGetRecvWrongCommunity(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, nil),
@@ -171,7 +171,7 @@ func TestGetRecvWrongCommunity(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("not-public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oid, 1),
@@ -220,7 +220,7 @@ func TestGetRequestTooBig(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(oids[0], nil),
@@ -236,7 +236,7 @@ func TestGetRequestTooBig(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				ErrorStatus: snmp.TooBigError,
 			},
@@ -300,7 +300,7 @@ func TestGetRequestGetBulk(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetBulkRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetBulkRequestType},
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
 				MaxRepetitions: 5,
@@ -316,7 +316,7 @@ func TestGetRequestGetBulk(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, 0),
@@ -364,7 +364,7 @@ func TestGetRequestGetBulkOne(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetBulkRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetBulkRequestType},
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
 				MaxRepetitions: 5,
@@ -380,7 +380,7 @@ func TestGetRequestGetBulkOne(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, 0),
@@ -422,7 +422,7 @@ func TestGetRequestGetBulkShort(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetBulkRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetBulkRequestType},
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
 				MaxRepetitions: 5,
@@ -438,7 +438,7 @@ func TestGetRequestGetBulkShort(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, 0),
@@ -469,7 +469,7 @@ func TestGetRequestGetBulkOdd(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetBulkRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetBulkRequestType},
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
 				MaxRepetitions: 2,
@@ -485,7 +485,7 @@ func TestGetRequestGetBulkOdd(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					snmp.MakeVarBind(scalarOID, 0),

--- a/client/engine.go
+++ b/client/engine.go
@@ -112,7 +112,12 @@ func (engine *Engine) startRequest(request *Request) {
 	// initialize request with next request ID to get the request key used to track send/recv/timeout
 	requestKey := request.init(engine.nextRequestID())
 
-	if err := engine.sendRequest(request); err != nil {
+	if _, exists := engine.requests[requestKey]; exists {
+		engine.log.Warnf("Start request %v allocated a duplicate requestKey: %v", request, requestKey)
+
+		request.fail(fmt.Errorf("Request ID collision: %v", requestKey))
+
+	} else if err := engine.sendRequest(request); err != nil {
 		engine.log.Debugf("Start request %v failed: %v", requestKey, err)
 
 		request.fail(err)

--- a/client/request.go
+++ b/client/request.go
@@ -88,7 +88,7 @@ func (request *Request) wait() error {
 
 func (request *Request) init(id requestID) ioKey {
 	request.id = id
-	request.send.PDU.SetRequestID(int(id))
+	request.send.RequestID = int(id)
 
 	return request.send.key()
 }

--- a/client/transport.go
+++ b/client/transport.go
@@ -21,15 +21,15 @@ func (key ioKey) String() string {
 }
 
 type IO struct {
-	Addr    net.Addr
-	Packet  snmp.Packet
-	PDUType snmp.PDUType
-	PDU     snmp.PDU
+	Addr   net.Addr
+	Packet snmp.Packet
+	snmp.PDUMeta
+	PDU snmp.PDU
 }
 
 func (io IO) key() ioKey {
 	return ioKey{
-		id:        io.PDU.GetRequestID(),
+		id:        io.RequestID,
 		community: string(io.Packet.Community),
 		addr:      io.Addr.String(),
 	}

--- a/client/transport_test.go
+++ b/client/transport_test.go
@@ -38,10 +38,10 @@ func (transport *testTransport) Resolve(addr string) (net.Addr, error) {
 }
 
 func (transport *testTransport) Send(io IO) error {
-	var requestID = io.PDU.GetRequestID()
+	var requestID = io.RequestID
 
 	// override requestID to 0 for assert.Equal() comparison
-	io.PDU.SetRequestID(0)
+	io.RequestID = 0
 
 	args := transport.MethodCalled(io.PDUType.String(), io)
 
@@ -49,7 +49,7 @@ func (transport *testTransport) Send(io IO) error {
 		// no response
 	} else {
 		recv := ret.(IO)
-		recv.PDU.SetRequestID(requestID)
+		recv.RequestID = requestID
 
 		transport.recvChan <- recv
 	}
@@ -83,7 +83,7 @@ func (transport *testTransport) mockGetTimeout(addr string, oid snmp.OID) {
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetRequestType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType},
 		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				snmp.MakeVarBind(oid, nil),
@@ -99,7 +99,7 @@ func (transport *testTransport) mockGet(addr string, oid snmp.OID, varBind snmp.
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetRequestType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType},
 		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				snmp.MakeVarBind(oid, nil),
@@ -111,7 +111,7 @@ func (transport *testTransport) mockGet(addr string, oid snmp.OID, varBind snmp.
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetResponseType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				varBind,
@@ -132,7 +132,7 @@ func (transport *testTransport) mockGetMany(addr string, oids []snmp.OID, varBin
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetRequestType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType},
 		PDU: snmp.GenericPDU{
 			VarBinds: reqVars,
 		},
@@ -142,7 +142,7 @@ func (transport *testTransport) mockGetMany(addr string, oids []snmp.OID, varBin
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetResponseType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 		PDU: snmp.GenericPDU{
 			VarBinds: varBinds,
 		},
@@ -156,7 +156,7 @@ func (transport *testTransport) mockGetNext(addr string, oid snmp.OID, varBind s
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetNextRequestType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetNextRequestType},
 		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				snmp.MakeVarBind(oid, nil),
@@ -168,7 +168,7 @@ func (transport *testTransport) mockGetNext(addr string, oid snmp.OID, varBind s
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetResponseType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 		PDU: snmp.GenericPDU{
 			VarBinds: []snmp.VarBind{
 				varBind,
@@ -189,7 +189,7 @@ func (transport *testTransport) mockGetNextMulti(addr string, oids []snmp.OID, v
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetNextRequestType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetNextRequestType},
 		PDU: snmp.GenericPDU{
 			VarBinds: requestVars,
 		},
@@ -199,7 +199,7 @@ func (transport *testTransport) mockGetNextMulti(addr string, oids []snmp.OID, v
 			Version:   snmp.SNMPv2c,
 			Community: []byte("public"),
 		},
-		PDUType: snmp.GetResponseType,
+		PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 		PDU: snmp.GenericPDU{
 			VarBinds: varBinds,
 		},

--- a/client/udp.go
+++ b/client/udp.go
@@ -123,7 +123,7 @@ func (udp *UDP) send(buf []byte, addr net.Addr) error {
 }
 
 func (udp *UDP) Send(send IO) error {
-	if err := send.Packet.PackPDU(send.PDUType, send.PDU); err != nil {
+	if err := send.Packet.PackPDU(send.PDUMeta, send.PDU); err != nil {
 		return ProtocolError{fmt.Errorf("packet.PackPDU: %v", err)}
 	} else if buf, err := send.Packet.Marshal(); err != nil {
 		return ProtocolError{fmt.Errorf("packet.Marshal: %v", err)}
@@ -153,10 +153,10 @@ func (udp *UDP) Recv() (recv IO, err error) {
 		return recv, ProtocolError{fmt.Errorf("packet.Unmarshal: %v", err)}
 	}
 
-	if pduType, pdu, err := recv.Packet.UnpackPDU(); err != nil {
+	if pduMeta, pdu, err := recv.Packet.UnpackPDU(); err != nil {
 		return recv, ProtocolError{fmt.Errorf("packet.UnpackPDU: %v", err)}
 	} else {
-		recv.PDUType = pduType
+		recv.PDUMeta = pduMeta
 		recv.PDU = pdu
 	}
 

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -246,7 +246,7 @@ func TestWalkBulk(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetBulkRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetBulkRequestType},
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
 				MaxRepetitions: 5,
@@ -262,7 +262,7 @@ func TestWalkBulk(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					numberVar,
@@ -280,7 +280,7 @@ func TestWalkBulk(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetBulkRequestType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetBulkRequestType},
 			PDU: snmp.BulkPDU{
 				NonRepeaters:   1,
 				MaxRepetitions: 5,
@@ -296,7 +296,7 @@ func TestWalkBulk(t *testing.T) {
 				Version:   snmp.SNMPv2c,
 				Community: []byte("public"),
 			},
-			PDUType: snmp.GetResponseType,
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType},
 			PDU: snmp.GenericPDU{
 				VarBinds: []snmp.VarBind{
 					numberVar,

--- a/snmp/bulk_pdu.go
+++ b/snmp/bulk_pdu.go
@@ -41,9 +41,9 @@ func (pdu BulkPDU) GetError() PDUError {
 	return PDUError{}
 }
 
-func (pdu BulkPDU) Pack(pduType PDUType) (asn1.RawValue, error) {
-	return packSequence(asn1.ClassContextSpecific, int(pduType),
-		pdu.RequestID,
+func (pdu BulkPDU) Pack(meta PDUMeta) (asn1.RawValue, error) {
+	return packSequence(asn1.ClassContextSpecific, int(meta.PDUType),
+		meta.RequestID,
 		pdu.NonRepeaters,
 		pdu.MaxRepetitions,
 		pdu.VarBinds,

--- a/snmp/bulk_pdu.go
+++ b/snmp/bulk_pdu.go
@@ -21,9 +21,6 @@ func (pdu *BulkPDU) unpack(raw asn1.RawValue) error {
 func (pdu BulkPDU) GetRequestID() int {
 	return pdu.RequestID
 }
-func (pdu BulkPDU) SetRequestID(id int) {
-	pdu.RequestID = id
-}
 
 func (pdu BulkPDU) String() string {
 	var scalars []string

--- a/snmp/generic_pdu.go
+++ b/snmp/generic_pdu.go
@@ -20,9 +20,6 @@ func (pdu *GenericPDU) unpack(raw asn1.RawValue) error {
 func (pdu GenericPDU) GetRequestID() int {
 	return pdu.RequestID
 }
-func (pdu GenericPDU) SetRequestID(id int) {
-	pdu.RequestID = id
-}
 
 func (pdu GenericPDU) String() string {
 	if pdu.ErrorStatus != 0 {

--- a/snmp/generic_pdu.go
+++ b/snmp/generic_pdu.go
@@ -50,9 +50,9 @@ func (pdu GenericPDU) GetError() PDUError {
 	}
 }
 
-func (pdu GenericPDU) Pack(pduType PDUType) (asn1.RawValue, error) {
-	return packSequence(asn1.ClassContextSpecific, int(pduType),
-		pdu.RequestID,
+func (pdu GenericPDU) Pack(meta PDUMeta) (asn1.RawValue, error) {
+	return packSequence(asn1.ClassContextSpecific, int(meta.PDUType),
+		meta.RequestID,
 		pdu.ErrorStatus,
 		pdu.ErrorIndex,
 		pdu.VarBinds,

--- a/snmp/packet.go
+++ b/snmp/packet.go
@@ -28,12 +28,12 @@ func (packet *Packet) PDUType() PDUType {
 	return PDUType(packet.RawPDU.Tag)
 }
 
-func (packet *Packet) UnpackPDU() (PDUType, PDU, error) {
+func (packet *Packet) UnpackPDU() (PDUMeta, PDU, error) {
 	return UnpackPDU(packet.RawPDU)
 }
 
-func (packet *Packet) PackPDU(pduType PDUType, pdu PDU) error {
-	if rawPDU, err := pdu.Pack(pduType); err != nil {
+func (packet *Packet) PackPDU(meta PDUMeta, pdu PDU) error {
+	if rawPDU, err := pdu.Pack(meta); err != nil {
 		return err
 	} else {
 		packet.RawPDU = rawPDU

--- a/snmp/packet_test.go
+++ b/snmp/packet_test.go
@@ -36,14 +36,14 @@ func testVarBind(oid OID, value interface{}) VarBind {
 }
 
 type packetTest struct {
-	bytes   []byte
-	packet  Packet
-	pduType PDUType
-	pdu     PDU
+	bytes  []byte
+	packet Packet
+	meta   PDUMeta
+	pdu    PDU
 }
 
 func testPacketMarshal(t *testing.T, test packetTest) {
-	if err := test.packet.PackPDU(test.pduType, test.pdu); err != nil {
+	if err := test.packet.PackPDU(test.meta, test.pdu); err != nil {
 		t.Fatalf("pdu.pack: %v", err)
 	}
 
@@ -64,7 +64,7 @@ func testPacketUnmarshal(t *testing.T, test packetTest) {
 		return
 	}
 
-	pduType, pdu, err := packet.UnpackPDU()
+	pduMeta, pdu, err := packet.UnpackPDU()
 	if err != nil {
 		t.Errorf("packet.UnpackPDU: %v", err)
 		return
@@ -72,7 +72,7 @@ func testPacketUnmarshal(t *testing.T, test packetTest) {
 
 	assert.Equal(t, test.packet.Version, packet.Version)
 	assert.Equal(t, test.packet.Community, packet.Community)
-	assert.Equal(t, test.pduType, pduType)
+	assert.Equal(t, test.meta, pduMeta)
 	assert.Equal(t, test.pdu, pdu)
 }
 
@@ -100,7 +100,7 @@ func TestPacketGetRequest(t *testing.T) {
 			Version:   SNMPv2c,
 			Community: []byte("public"),
 		},
-		pduType: GetNextRequestType,
+		meta: PDUMeta{GetNextRequestType, 1337},
 		pdu: GenericPDU{
 			RequestID: 1337,
 			VarBinds: []VarBind{
@@ -122,7 +122,7 @@ func TestPacketGetResponse(t *testing.T) {
 			Version:   SNMPv2c,
 			Community: []byte("public"),
 		},
-		pduType: GetResponseType,
+		meta: PDUMeta{GetResponseType, 24800755},
 		pdu: GenericPDU{
 			RequestID: 24800755,
 			VarBinds: []VarBind{
@@ -144,7 +144,7 @@ func TestPacketCounter32(t *testing.T) {
 			Version:   SNMPv2c,
 			Community: []byte("public"),
 		},
-		pduType: GetResponseType,
+		meta: PDUMeta{GetResponseType, 698234863},
 		pdu: GenericPDU{
 			RequestID: 698234863,
 			VarBinds: []VarBind{
@@ -165,7 +165,7 @@ func TestPacketNoSuchInstance(t *testing.T) {
 			Version:   SNMPv2c,
 			Community: []byte("public"),
 		},
-		pduType: GetResponseType,
+		meta: PDUMeta{GetResponseType, 1198209160},
 		pdu: GenericPDU{
 			RequestID: 1198209160,
 			VarBinds: []VarBind{
@@ -187,7 +187,7 @@ func TestPacketGetBulk(t *testing.T) {
 			Version:   SNMPv2c,
 			Community: []byte("public"),
 		},
-		pduType: GetBulkRequestType,
+		meta: PDUMeta{GetBulkRequestType, 745174553},
 		pdu: BulkPDU{
 			RequestID:      745174553,
 			NonRepeaters:   0,

--- a/snmp/pdu.go
+++ b/snmp/pdu.go
@@ -12,7 +12,6 @@ type PDUError struct {
 
 type PDU interface {
 	GetRequestID() int
-	SetRequestID(int)
 
 	GetError() PDUError
 

--- a/snmp/pdu.go
+++ b/snmp/pdu.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 )
 
+type PDUMeta struct {
+	PDUType   PDUType
+	RequestID int
+}
+
 type PDUError struct {
 	ErrorStatus ErrorStatus
 	VarBind     VarBind
@@ -15,14 +20,14 @@ type PDU interface {
 
 	GetError() PDUError
 
-	Pack(PDUType) (asn1.RawValue, error)
+	Pack(PDUMeta) (asn1.RawValue, error)
 }
 
-func UnpackPDU(raw asn1.RawValue) (PDUType, PDU, error) {
+func UnpackPDU(raw asn1.RawValue) (PDUMeta, PDU, error) {
 	var pduType = PDUType(raw.Tag)
 
 	if raw.Class != asn1.ClassContextSpecific {
-		return pduType, nil, fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
+		return PDUMeta{PDUType: pduType}, nil, fmt.Errorf("unexpected PDU: ASN.1 class=%d tag=%d", raw.Class, raw.Tag)
 	}
 
 	switch pduType {
@@ -31,16 +36,16 @@ func UnpackPDU(raw asn1.RawValue) (PDUType, PDU, error) {
 
 		err := pdu.unpack(raw)
 
-		return pduType, pdu, err
+		return PDUMeta{pduType, pdu.RequestID}, pdu, err
 
 	case GetBulkRequestType:
 		var pdu BulkPDU
 
 		err := pdu.unpack(raw)
 
-		return pduType, pdu, err
+		return PDUMeta{pduType, pdu.RequestID}, pdu, err
 
 	default:
-		return pduType, nil, fmt.Errorf("Unknown PDUType=%v", pduType)
+		return PDUMeta{PDUType: pduType}, nil, fmt.Errorf("Unknown PDUType=%v", pduType)
 	}
 }


### PR DESCRIPTION
The new `snmp:PDU.SetRequestID()` interface in #8 was broken, because it was getting called on a non-pointer receiver, making it a no-op. All client requests were running on the wire with `RequestID: 0`, causing any overlapping requests to hang without timeouts.