### PR TITLE
Fix GetBulk Walk with empty vars

### DIFF
--- a/client/walk.go
+++ b/client/walk.go
@@ -118,15 +118,22 @@ func (client *Client) walkGetBulk(scalars []snmp.OID, entries []snmp.OID, walkFu
 			// no scalar vars matched !?
 		}
 
+		var ok = false
+
 		for _, entryVars := range entryList {
 			if !walkEntryVars(entries, walkOIDs, entryVars) {
-				// did not make progress
-				return nil
-			}
-
-			if err := walkFunc(scalarVars, entryVars); err != nil {
+				// no vars made progress, ignore the remainder
+				ok = false
+				break
+			} else if err := walkFunc(scalarVars, entryVars); err != nil {
 				return err
+			} else {
+				ok = true
 			}
+		}
+
+		if !ok {
+			return nil
 		}
 	}
 }

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -88,6 +88,16 @@ func TestWalkScalarsOnly(t *testing.T) {
 	})
 }
 
+func TestWalkEmpty(t *testing.T) {
+	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		testWalk(t, client, walkTest{
+			scalars: []snmp.OID{},
+			entries: []snmp.OID{},
+			results: []walkResult{},
+		})
+	})
+}
+
 func TestWalk(t *testing.T) {
 	var ifNumber = snmp.MustParseOID(".1.3.6.1.2.1.2.1")                 // IF-MIB::ifNumber
 	var ifName = snmp.MustParseOID(".1.3.6.1.2.1.31.1.1.1.1")            // IF-MIB::ifName
@@ -316,6 +326,17 @@ func TestWalkBulk(t *testing.T) {
 				{scalars: []snmp.VarBind{numberVar}, entries: []snmp.VarBind{indexVars[0], nameVars[0]}},
 				{scalars: []snmp.VarBind{numberVar}, entries: []snmp.VarBind{indexVars[1], nameVars[1]}},
 			},
+		})
+	})
+}
+
+func TestWalkBulkEmpty(t *testing.T) {
+	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		testWalk(t, client, walkTest{
+			useBulk: true,
+			scalars: []snmp.OID{},
+			entries: []snmp.OID{},
+			results: []walkResult{},
 		})
 	})
 }


### PR DESCRIPTION
Fixes #10

The existing `walkGetNext` with `client.GetNextSplit` returning `nil` worked correctly in this case, hitting the `if !walkEntryVars(...)` => `return nil` case.

The new `walkGetBulk` with `client.GetBulk` returning `nil` did not work correctly, because the `return` case was within the for loop over the `entryList` vars, which never executed.