### PR TITLE
Return partial table entries together with entry errors from API

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -40,6 +40,7 @@ func (options *Options) InitFlags() {
 func (options *Options) Parse() []string {
 	flag.Parse()
 
+	SetLogging(options.Logging.MakeLogging())
 	mibs.SetLogging(options.MIBsLogging.MakeLogging())
 	client.SetLogging(options.ClientLogging.MakeLogging())
 

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"github.com/qmsk/go-logging"
+)
+
+var Log logging.Logging // public for cmd packages
+
+func SetLogging(l logging.Logging) {
+	Log = l
+}

--- a/cmd/snmptable/main.go
+++ b/cmd/snmptable/main.go
@@ -44,7 +44,11 @@ func snmptable(client mibs.Client, id mibs.ID) error {
 	}
 	fmt.Fprintf(writer, "\n")
 
-	walkRow := func(indexValues mibs.IndexValues, entryValues mibs.EntryValues) error {
+	walkRow := func(indexValues mibs.IndexValues, entryValues mibs.EntryValues, err error) error {
+		if err != nil {
+			cmd.Log.Warnf("%v", err)
+		}
+
 		for i, _ := range table.IndexSyntax {
 			fmt.Fprintf(writer, "%v\t", indexValues[i])
 		}

--- a/mibs/client.go
+++ b/mibs/client.go
@@ -68,14 +68,10 @@ func (client Client) WalkObjects(objects []*Object, f func(*Object, IndexValues,
 	})
 }
 
-func (client Client) WalkTable(table *Table, f func(IndexValues, EntryValues) error) error {
+func (client Client) WalkTable(table *Table, f func(IndexValues, EntryValues, error) error) error {
 	return client.Walk(table.EntryOIDs(), func(varBinds []snmp.VarBind) error {
-		if indexValues, entryValues, err := table.Unpack(varBinds); err != nil {
-			return err
-		} else if err := f(indexValues, entryValues); err != nil {
-			return err
-		} else {
-			return nil
-		}
+		indexValues, entryValues, err := table.Unpack(varBinds)
+
+		return f(indexValues, entryValues, err)
 	})
 }

--- a/mibs/index.go
+++ b/mibs/index.go
@@ -22,7 +22,7 @@ func (indexSyntax IndexSyntax) UnpackIndex(index []int) (IndexValues, error) {
 
 	for i, indexObject := range indexSyntax {
 		if indexValue, indexRemaining, err := indexObject.Syntax.UnpackIndex(index); err != nil {
-			return nil, fmt.Errorf("Invalid index for %v: %v", indexObject, err)
+			return values, fmt.Errorf("Invalid index for %v: %v", indexObject, err)
 		} else {
 			values[i] = indexValue
 			index = indexRemaining


### PR DESCRIPTION
If any table walk `GetNext` returned any field with an invalid index or entry syntax value, then the entire table entry would be discarded and the table walk aborted.

Change `mibs:Client.WalkTable()` to report partial (nil-valued) `IndexValues` and `EntryValues` together with the `error` to the caller, allowing it to either abort on the error as before, or use the partial values.

Change `snmptable` to log warnings for these invalid values:

```
$GOPATH/bin/snmptable public@localhost IF-MIB::ifXTable
WARN: Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.5] OID for IF-MIB::ifInMulticastPkts: index [5] != expected [76]
WARN: Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.76] OID for IF-MIB::ifInMulticastPkts: index [76] != expected [77]
WARN: Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.77] OID for IF-MIB::ifInMulticastPkts: index [77] != expected [78]
WARN: Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.78] OID for IF-MIB::ifInMulticastPkts: index [78] != expected [238]
WARN: Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.238] OID for IF-MIB::ifInMulticastPkts: index [238] != expected [241]
IF-MIB::ifIndex |       IF-MIB::ifName IF-MIB::ifInMulticastPkts IF-MIB::ifInBroadcastPkts IF-MIB::ifOutMulticastPkts IF-MIB::ifOutBroadcastPkts IF-MIB::ifHCInOctets IF-MIB::ifHCInUcastPkts IF-MIB::ifHCInMulticastPkts IF-MIB::ifHCInBroadcastPkts IF-MIB::ifHCOutOctets IF-MIB::ifHCOutUcastPkts IF-MIB::ifHCOutMulticastPkts IF-MIB::ifHCOutBroadcastPkts IF-MIB::ifLinkUpDownTrapEnable IF-MIB::ifHighSpeed IF-MIB::ifPromiscuousMode IF-MIB::ifConnectorPresent IF-MIB::ifAlias IF-MIB::ifCounterDiscontinuityTime
---             |       ---            ---                       ---                       ---                        ---                        ---                  ---                     ---                         ---                         ---                   ---                      ---                          ---                          ---                            ---                 ---                       ---                        ---             ---
1               |       lo             0                         0                         0                          0                          465293971            355687                  0                           0                           465293971             355687                   0                            0                            <nil>                          10                  false                     false                                      0s
2               |       enp0s31f6      43092                     0                         0                          0                          1950089499           2375528                 43092                       0                           1390536866            1990331                  0                            0                            <nil>                          0                   false                     true                                       0s
4               |       wlp4s0         0                         0                         0                          0                          10497348436          11189832                0                           0                           7709501994            8631168                  0                            0                            <nil>                          0                   false                     true                                       0s
5               |       docker0        0                         0                         0                          0                          22727544             255680                  0                           0                           1565840915            292479                   0                            0                            <nil>                          0                   false                     true                                       0s
76              |       vboxnet0       <nil>                     0                         0                          0                          0                    0                       0                           0                           0                     0                        0                            0                            <nil>                          10                  false                     true                                       0s
77              |       vboxnet1       <nil>                     0                         0                          0                          0                    0                       0                           0                           156482                1739                     0                            0                            <nil>                          10                  false                     true                                       0s
78              |       vboxnet2       <nil>                     0                         0                          0                          0                    0                       0                           0                           0                     0                        0                            0                            <nil>                          10                  false                     true                                       0s
238             |       veth0f39fbf    <nil>                     0                         0                          0                          0                    0                       0                           0                           247170                2848                     0                            0                            <nil>                          10000               false                     true                                       0s
241             |       wwp0s20f0u3c2  <nil>                     0                         0                          0                          0                    0                       0                           0                           0                     0                        0                            0                            <nil>                          0                   false                     true                                       0s
241             |       <nil>          0                         <nil>                     <nil>                      <nil>                      <nil>                <nil>                   <nil>                       <nil>                       <nil>                 <nil>                    <nil>                        <nil>                        <nil>                          <nil>               <nil>                     <nil>                      <nil>           <nil>
```

Change the snmpbot `/api/.../tables/...` to return partial results with `null` values + errors:

```json
{
  "ID": "IF-MIB::ifXTable",
  "IndexKeys": [
    "IF-MIB::ifIndex"
  ],
  "ObjectKeys": [
    "IF-MIB::ifName",
    "IF-MIB::ifInMulticastPkts",
    "IF-MIB::ifInBroadcastPkts",
    "IF-MIB::ifOutMulticastPkts",
    "IF-MIB::ifOutBroadcastPkts",
    "IF-MIB::ifHCInOctets",
    "IF-MIB::ifHCInUcastPkts",
    "IF-MIB::ifHCInMulticastPkts",
    "IF-MIB::ifHCInBroadcastPkts",
    "IF-MIB::ifHCOutOctets",
    "IF-MIB::ifHCOutUcastPkts",
    "IF-MIB::ifHCOutMulticastPkts",
    "IF-MIB::ifHCOutBroadcastPkts",
    "IF-MIB::ifLinkUpDownTrapEnable",
    "IF-MIB::ifHighSpeed",
    "IF-MIB::ifPromiscuousMode",
    "IF-MIB::ifConnectorPresent",
    "IF-MIB::ifAlias",
    "IF-MIB::ifCounterDiscontinuityTime"
  ],
  "Entries": [
    ...
    {
      "HostID": "localhost",
      "Index": {
        "IF-MIB::ifIndex": 76
      },
      "Objects": {
        "IF-MIB::ifAlias": "",
        "IF-MIB::ifConnectorPresent": "true",
        "IF-MIB::ifCounterDiscontinuityTime": 0,
        "IF-MIB::ifHCInBroadcastPkts": 0,
        "IF-MIB::ifHCInMulticastPkts": 0,
        "IF-MIB::ifHCInOctets": 0,
        "IF-MIB::ifHCInUcastPkts": 0,
        "IF-MIB::ifHCOutBroadcastPkts": 0,
        "IF-MIB::ifHCOutMulticastPkts": 0,
        "IF-MIB::ifHCOutOctets": 0,
        "IF-MIB::ifHCOutUcastPkts": 0,
        "IF-MIB::ifHighSpeed": 10,
        "IF-MIB::ifInBroadcastPkts": 0,
        "IF-MIB::ifInMulticastPkts": null,
        "IF-MIB::ifLinkUpDownTrapEnable": null,
        "IF-MIB::ifName": "vboxnet0",
        "IF-MIB::ifOutBroadcastPkts": 0,
        "IF-MIB::ifOutMulticastPkts": 0,
        "IF-MIB::ifPromiscuousMode": "false"
      }
    },
  ],
  "Errors": [
    {
      "HostID": "localhost",
      "Error": "Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.5] OID for IF-MIB::ifInMulticastPkts: index [5] != expected [76]"
    },
    {
      "HostID": "localhost",
      "Error": "Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.76] OID for IF-MIB::ifInMulticastPkts: index [76] != expected [77]"
    },
    {
      "HostID": "localhost",
      "Error": "Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.77] OID for IF-MIB::ifInMulticastPkts: index [77] != expected [78]"
    },
    {
      "HostID": "localhost",
      "Error": "Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.78] OID for IF-MIB::ifInMulticastPkts: index [78] != expected [238]"
    },
    {
      "HostID": "localhost",
      "Error": "Mismatching VarBind[.1.3.6.1.2.1.31.1.1.1.2.238] OID for IF-MIB::ifInMulticastPkts: index [238] != expected [241]"
    }
  ]
}
```