### PR TITLE
snmp: use asn1.MarshalWithParams() for pack() 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - '1.9'
   - '1.10'
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ REST (HTTP/JSON) API for writing SNMP applications.
 
 ## Requirements
 
+### Go version 1.10
+
+* [encoding/asn1: add MarshalWithParams](https://github.com/golang/go/commit/c32626a4ce9293979c407c4e6a799d1bec37aa18#diff-3c740598b49abcc8e5f74f801dc75255)
+
 ### Go version 1.9
 
 * [encoding/asn1: add NullBytes and NullRawValue for working with ASN.1 NULL](https://github.com/golang/go/commit/d9b1f9e85ee097ebc95c5904cee921ba7be4f732)

--- a/snmp/marshal.go
+++ b/snmp/marshal.go
@@ -2,24 +2,44 @@ package snmp
 
 import (
 	"encoding/asn1"
+	"fmt"
 )
 
-// XXX: workaround lack of asn1.MarshalWithParameters
+// pack value with custom class/tag, returning a RawValue for further use in sequences/etc.
+// returns RawValue with FullBytes set. The .Bytes will always be nil.
 func pack(cls int, tag int, value interface{}) (asn1.RawValue, error) {
-	var raw asn1.RawValue
-
-	if value == nil {
-		raw = asn1.NullRawValue
-	} else if buf, err := asn1.Marshal(value); err != nil {
-		return raw, err
-	} else if _, err := asn1.Unmarshal(buf, &raw); err != nil {
-		return raw, err
+	var params string
+	var raw = asn1.RawValue{
+		Class: cls,
+		Tag:   tag,
 	}
 
-	if cls != asn1.ClassUniversal {
-		raw.Class = cls
-		raw.Tag = tag
-		raw.FullBytes = nil
+	// asn.MarshalWithParams does not allow marshalling non-raw nil values
+	if value == nil {
+		raw.Bytes = []byte{} // explicit empty value for nil
+
+		if bytes, err := asn1.Marshal(raw); err != nil {
+			return raw, err
+		} else {
+			raw.FullBytes = bytes
+		}
+	} else {
+		switch raw.Class {
+		case asn1.ClassUniversal:
+
+		case asn1.ClassContextSpecific:
+			params = fmt.Sprintf("tag:%d", raw.Tag)
+		case asn1.ClassApplication:
+			params = fmt.Sprintf("application,tag:%d", raw.Tag)
+		default:
+			return raw, fmt.Errorf("unable to unpack raw value with class=%d", raw.Class)
+		}
+
+		if bytes, err := asn1.MarshalWithParams(value, params); err != nil {
+			return raw, err
+		} else {
+			raw.FullBytes = bytes
+		}
 	}
 
 	return raw, nil

--- a/snmp/packet_test.go
+++ b/snmp/packet_test.go
@@ -22,14 +22,9 @@ func decodeTestPacket(str string) []byte {
 func testVarBind(oid OID, value interface{}) VarBind {
 	varBind := MakeVarBind(oid, value)
 
-	if varBind.RawValue.Bytes == nil {
-		varBind.RawValue.Bytes = []byte{}
-	}
-
-	if data, err := asn1.Marshal(varBind.RawValue); err != nil {
+	// ensure that varBind has both Bytes *and* FullBytes, for comparisons with unmarshal
+	if _, err := asn1.Unmarshal(varBind.RawValue.FullBytes, &varBind.RawValue); err != nil {
 		panic(err)
-	} else {
-		varBind.RawValue.FullBytes = data
 	}
 
 	return varBind

--- a/snmp/varbind.go
+++ b/snmp/varbind.go
@@ -178,7 +178,11 @@ func (varBind *VarBind) Set(genericValue interface{}) error {
 }
 
 func (varBind *VarBind) SetNull() {
-	varBind.RawValue = asn1.NullRawValue
+	if rawValue, err := pack(asn1.ClassUniversal, asn1.TagNull, nil); err != nil {
+		panic(err)
+	} else {
+		varBind.RawValue = rawValue
+	}
 }
 
 func (varBind *VarBind) SetError(errorValue ErrorValue) error {


### PR DESCRIPTION
Fixes #3

Slight optimization (?) to avoid the marshal/unmarshal dance.

# TODO

- [ ] Benchmark?