### PR TITLE
Extend .../objects API to filter by ?table=...

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,8 @@ Query matching objects from probed MIBs for a specific host (dynamic or configur
 
 Use multiple `?object=A&object=B` filters to query different objects. Use `?object=MIB::foo*` filters to query multiple matching objects.
 
+Use `?table=IF-MIB::ifTable` to query for objects belonging to matching tables. These can also be combined with `?object=` filters, e.g. `GET /api/hosts/public@localhost/objects/?table=IF-MIB::ifXTable&object=*HC*Pkts` to return 64-bit per-interface packet counters as separate objects.
+
 ```json
    {
       "IndexKeys" : [

--- a/api/object.go
+++ b/api/object.go
@@ -69,4 +69,5 @@ type ObjectQuery struct {
 type ObjectsQuery struct {
 	Hosts   []string `schema:"host"`
 	Objects []string `schema:"object"`
+	Tables  []string `schema:"table"`
 }

--- a/server/host.go
+++ b/server/host.go
@@ -285,6 +285,7 @@ func (route hostObjectsRoute) Index(name string) (web.Resource, error) {
 			engine:  route.engine,
 			hosts:   MakeHosts(route.host),
 			objects: route.host.Objects(),
+			tables:  route.host.Tables(),
 		}, nil
 	} else if object, err := route.host.resolveObject(name); err != nil {
 		return nil, web.Errorf(404, "%v", err)

--- a/server/table.go
+++ b/server/table.go
@@ -98,6 +98,8 @@ func (tables Tables) Filter(filters ...string) Tables {
 		}
 	}
 
+	log.Debugf("Filter %d => %d tables: %#v", len(tables), len(filtered), filters)
+
 	return filtered
 }
 


### PR DESCRIPTION
Workaround for #18

Allows querying for objects belonging to a table, without attempting to group them into entries with an index.

The `.../tables/X` and `.../objects/?table=X` SNMP `GETNEXT` queries are exactly the same, the only difference is how the server processes the walk results.