### PR TITLE
Improved WalkTable(...) with min-index tracking

### DIFF
--- a/client/walk.go
+++ b/client/walk.go
@@ -265,10 +265,22 @@ func (client *Client) GetScalars(oids []snmp.OID) ([]snmp.VarBind, error) {
 	})
 }
 
+// Perform GetNext walk steps for the given objects, yielding VarBinds of objects underneath given oid.
+// Yields EndOfMibViewValue VarBinds once walk goes outside of the given OIDs.
+//
+// The objects are not assumed to be related to eachother.
+// This will yield partial EndOfMibView results until all OIDs have been walked through.
 func (client *Client) WalkObjects(oids []snmp.OID, walkFunc WalkFunc) error {
 	return client.WalkWithOptions(WalkOptions{Objects: oids}, walkFunc)
 }
 
+// Perform GetNext walk steps for the given objects, yielding VarBinds of objects underneath given oid.
+// Yields EndOfMibView VarBinds once walk goes outside of the given OIDs.
+// Yields NoSuchInstance VarBinds if walk step returns inconsistent OID indexes.
+//
+// The objects are assuemd to be related to eachother, and each step yields objects with the same OID index suffix.
+// This will yield objects matching the minimum index suffix for each step, masking objects with non-matching indexes with synthesized NoSuchInstance VarBinds.
+// This will yield partial EndOfMibView results until all OIDs have been walked through.
 func (client *Client) WalkTable(entryOids []snmp.OID, walkFunc WalkFunc) error {
 	return client.WalkWithOptions(WalkOptions{TableEntries: entryOids}, walkFunc)
 }

--- a/client/walk.go
+++ b/client/walk.go
@@ -23,7 +23,7 @@ func walkScalarVars(oids []snmp.OID, varBinds []snmp.VarBind) bool {
 	return ok
 }
 
-func walkEntryVars(rootOIDs []snmp.OID, walkOIDs []snmp.OID, varBinds []snmp.VarBind) bool {
+func walkObjectVars(rootOIDs []snmp.OID, walkOIDs []snmp.OID, varBinds []snmp.VarBind) bool {
 	var ok = false
 
 	for i, varBind := range varBinds {
@@ -44,6 +44,16 @@ func walkEntryVars(rootOIDs []snmp.OID, walkOIDs []snmp.OID, varBinds []snmp.Var
 	return ok
 }
 
+type WalkOptions struct {
+	// scalar objects with only one instance (.0), each walk step returns the same object instance
+	Scalars []snmp.OID
+
+	// mixed objects, each walk step may return objects with different indexes
+	Objects []snmp.OID
+}
+
+type WalkFunc func(vars []snmp.VarBind) error
+
 // Object/Table traversal using GetNext.
 //
 // Scalar OIDs are objects that are always fetched for every traversed row.
@@ -55,22 +65,22 @@ func walkEntryVars(rootOIDs []snmp.OID, walkOIDs []snmp.OID, varBinds []snmp.Var
 // Returns if none of the entry varBinds are within the requested OIDs.
 //
 // Splits into multiple requests if the number of OIDs exceeds options.MaxVars.
-func (client *Client) WalkWithScalars(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
+func (client *Client) WalkWithOptions(options WalkOptions, walkFunc WalkFunc) error {
 	if client.options.NoBulk {
-		return client.walkGetNext(scalars, entries, walkFunc)
+		return client.walkGetNext(options, walkFunc)
 	} else {
-		return client.walkGetBulk(scalars, entries, walkFunc)
+		return client.walkGetBulk(options, walkFunc)
 	}
 }
 
-func (client *Client) walkGetNext(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
-	var walkOIDs = make([]snmp.OID, len(scalars)+len(entries))
+func (client *Client) walkGetNext(options WalkOptions, walkFunc WalkFunc) error {
+	var walkOIDs = make([]snmp.OID, len(options.Scalars)+len(options.Objects))
 
-	for i, oid := range scalars {
+	for i, oid := range options.Scalars {
 		walkOIDs[i] = oid
 	}
-	for i, oid := range entries {
-		walkOIDs[len(scalars)+i] = oid
+	for i, oid := range options.Objects {
+		walkOIDs[len(options.Scalars)+i] = oid
 	}
 
 	for {
@@ -80,50 +90,58 @@ func (client *Client) walkGetNext(scalars []snmp.OID, entries []snmp.OID, walkFu
 			return err
 		}
 
-		var scalarVars = varBinds[:len(scalars)]
-		var entryVars = varBinds[len(scalars):]
-
-		if !walkScalarVars(scalars, scalarVars) {
+		if !walkScalarVars(options.Scalars, varBinds[0:len(options.Scalars)]) {
 			// no scalar vars matched !?
 		}
 
-		if !walkEntryVars(entries, walkOIDs[len(scalars):], entryVars) {
+		if !walkObjectVars(options.Objects, walkOIDs[len(options.Scalars):len(options.Scalars)+len(options.Objects)], varBinds[len(options.Scalars):len(options.Scalars)+len(options.Objects)]) {
 			// did not make progress
 			return nil
 		}
 
-		if err := walkFunc(scalarVars, entryVars); err != nil {
+		if err := walkFunc(varBinds); err != nil {
 			return err
 		}
 	}
 }
 
-func (client *Client) walkGetBulk(scalars []snmp.OID, entries []snmp.OID, walkFunc func(scalars []snmp.VarBind, entries []snmp.VarBind) error) error {
-	var walkOIDs = make([]snmp.OID, len(entries))
+func (client *Client) walkGetBulk(options WalkOptions, walkFunc WalkFunc) error {
+	var walkOIDs = make([]snmp.OID, len(options.Objects))
 
-	for i, oid := range entries {
+	for i, oid := range options.Objects {
 		walkOIDs[i] = oid
 	}
 
 	for {
 		// TODO: request splitting
-		scalarVars, entryList, err := client.GetBulk(scalars, walkOIDs)
+		scalarVars, entryList, err := client.GetBulk(options.Scalars, walkOIDs)
 		if err != nil {
 			return err
 		}
 
-		if !walkScalarVars(scalars, scalarVars) {
+		if !walkScalarVars(options.Scalars, scalarVars) {
 			// no scalar vars matched !?
 		}
 
 		var ok = false
 
 		for _, entryVars := range entryList {
-			if !walkEntryVars(entries, walkOIDs, entryVars) {
+			if !walkObjectVars(options.Objects, walkOIDs[0:len(options.Objects)], entryVars[0:len(options.Objects)]) {
 				// no vars made progress, ignore the remainder
 				ok = false
 				break
-			} else if err := walkFunc(scalarVars, entryVars); err != nil {
+			}
+
+			var vars = make([]snmp.VarBind, len(options.Scalars)+len(options.Objects))
+
+			for i, v := range scalarVars {
+				vars[i] = v
+			}
+			for i, v := range entryVars {
+				vars[len(scalarVars)+i] = v
+			}
+
+			if err := walkFunc(vars); err != nil {
 				return err
 			} else {
 				ok = true
@@ -136,22 +154,17 @@ func (client *Client) walkGetBulk(scalars []snmp.OID, entries []snmp.OID, walkFu
 	}
 }
 
-func (client *Client) Walk(oids []snmp.OID, walkFunc func(varBinds []snmp.VarBind) error) error {
-	return client.WalkWithScalars(nil, oids, func(scalars []snmp.VarBind, entries []snmp.VarBind) error {
-		return walkFunc(entries)
+// Perform a single GetNext walk step, returning either objects underneath given oid, or EndOfMibViewValue
+func (client *Client) GetScalars(oids []snmp.OID) ([]snmp.VarBind, error) {
+	var retVars []snmp.VarBind
+
+	return retVars, client.WalkWithOptions(WalkOptions{Objects: oids}, func(vars []snmp.VarBind) error {
+		retVars = vars
+
+		return nil
 	})
 }
 
-// Perform a single GetNext walk step, returning either objects underneath given oid, or EndOfMibViewValue
-func (client *Client) WalkScalars(oids []snmp.OID) ([]snmp.VarBind, error) {
-	// request splitting
-	if varBinds, err := client.GetNextSplit(oids); err != nil {
-		return nil, err
-	} else {
-		if !walkScalarVars(oids, varBinds) {
-			// no scalar vars matched !?
-		}
-
-		return varBinds, err
-	}
+func (client *Client) WalkObjects(oids []snmp.OID, walkFunc WalkFunc) error {
+	return client.WalkWithOptions(WalkOptions{Objects: oids}, walkFunc)
 }

--- a/client/walk.go
+++ b/client/walk.go
@@ -44,12 +44,83 @@ func walkObjectVars(rootOIDs []snmp.OID, walkOIDs []snmp.OID, varBinds []snmp.Va
 	return ok
 }
 
+func indexCmp(a []int, b []int) int {
+	if len(a) < len(b) {
+		return -1
+	} else if len(a) > len(b) {
+		return +1
+	}
+
+	for i, _ := range a {
+		if a[i] < b[i] {
+			return -1
+		} else if a[i] > b[i] {
+			return +1
+		}
+	}
+
+	return 0 // equal
+}
+
+func walkEntryVars(rootOIDs []snmp.OID, walkOIDs []snmp.OID, varBinds []snmp.VarBind) bool {
+	var ok = false
+	var entryIndex []int
+
+	// select minimum index
+	for i, varBind := range varBinds {
+		var rootOID = rootOIDs[i]
+		var oid = varBind.OID()
+
+		if errorValue := varBind.ErrorValue(); errorValue == snmp.EndOfMibViewValue {
+			// explicit SNMPv2 break
+			continue
+		} else if oid.Equals(walkOIDs[i]) {
+			// not making progress
+			continue
+
+		} else if index := rootOID.Index(oid); index == nil {
+			// walked out of tree
+			varBinds[i] = snmp.MakeVarBind(rootOID, snmp.EndOfMibViewValue)
+			continue
+
+		} else if entryIndex == nil || indexCmp(entryIndex, index) > 0 {
+			entryIndex = index
+		}
+
+		// at least one object is making progress
+		ok = true
+	}
+
+	// select objects with matching index
+	for i, varBind := range varBinds {
+		var rootOID = rootOIDs[i]
+		var oid = varBind.OID()
+		var entryOID = rootOID.Extend(entryIndex...)
+
+		if index := rootOID.Index(oid); index == nil {
+			// error, leave as-is
+		} else if indexCmp(entryIndex, index) != 0 {
+			// hole, replace with snmp.NoSuchInstanceValue
+			varBinds[i] = snmp.MakeVarBind(entryOID, snmp.NoSuchInstanceValue)
+		} else {
+			// valid, leave as-is
+		}
+
+		walkOIDs[i] = entryOID
+	}
+
+	return ok
+}
+
 type WalkOptions struct {
 	// scalar objects with only one instance (.0), each walk step returns the same object instance
 	Scalars []snmp.OID
 
 	// mixed objects, each walk step may return objects with different indexes
 	Objects []snmp.OID
+
+	// table entry objects, each walk step returns objects with the same index
+	TableEntries []snmp.OID
 }
 
 type WalkFunc func(vars []snmp.VarBind) error
@@ -74,18 +145,23 @@ func (client *Client) WalkWithOptions(options WalkOptions, walkFunc WalkFunc) er
 }
 
 func (client *Client) walkGetNext(options WalkOptions, walkFunc WalkFunc) error {
-	var walkOIDs = make([]snmp.OID, len(options.Scalars)+len(options.Objects))
+	var walkOIDs = make([]snmp.OID, len(options.Scalars)+len(options.Objects)+len(options.TableEntries))
+	var objectsOffset = len(options.Scalars)
+	var entriesOffset = len(options.Scalars) + len(options.Objects)
 
 	for i, oid := range options.Scalars {
 		walkOIDs[i] = oid
 	}
 	for i, oid := range options.Objects {
-		walkOIDs[len(options.Scalars)+i] = oid
+		walkOIDs[objectsOffset+i] = oid
+	}
+	for i, oid := range options.TableEntries {
+		walkOIDs[entriesOffset+i] = oid
 	}
 
 	if len(walkOIDs) == 0 {
 		return nil
- 	}
+	}
 
 	for {
 		// request splitting
@@ -103,21 +179,30 @@ func (client *Client) walkGetNext(options WalkOptions, walkFunc WalkFunc) error 
 			return nil
 		}
 
+		if len(options.TableEntries) > 0 && !walkEntryVars(options.TableEntries, walkOIDs[entriesOffset:entriesOffset+len(options.TableEntries)], varBinds[entriesOffset:entriesOffset+len(options.TableEntries)]) {
+			// did not make progress
+			return nil
+		}
+
 		if err := walkFunc(varBinds); err != nil {
 			return err
 		}
 
-		if len(options.Objects) == 0 {
+		if len(options.Objects) == 0 && len(options.TableEntries) == 0 {
 			return nil
 		}
 	}
 }
 
 func (client *Client) walkGetBulk(options WalkOptions, walkFunc WalkFunc) error {
-	var walkOIDs = make([]snmp.OID, len(options.Objects))
+	var walkOIDs = make([]snmp.OID, len(options.Objects)+len(options.TableEntries))
+	var entriesOffset = len(options.Objects)
 
 	for i, oid := range options.Objects {
 		walkOIDs[i] = oid
+	}
+	for i, oid := range options.TableEntries {
+		walkOIDs[entriesOffset+i] = oid
 	}
 
 	for {
@@ -134,13 +219,19 @@ func (client *Client) walkGetBulk(options WalkOptions, walkFunc WalkFunc) error 
 		var ok = false
 
 		for _, entryVars := range entryList {
-			if !walkObjectVars(options.Objects, walkOIDs[0:len(options.Objects)], entryVars[0:len(options.Objects)]) {
+			if len(options.Objects) > 0 && !walkObjectVars(options.Objects, walkOIDs[0:len(options.Objects)], entryVars[0:len(options.Objects)]) {
 				// no vars made progress, ignore the remainder
 				ok = false
 				break
 			}
 
-			var vars = make([]snmp.VarBind, len(options.Scalars)+len(options.Objects))
+			if len(options.TableEntries) > 0 && !walkEntryVars(options.TableEntries, walkOIDs[entriesOffset:entriesOffset+len(options.TableEntries)], entryVars[entriesOffset:entriesOffset+len(options.TableEntries)]) {
+				// no vars made progress, ignore the remainder
+				ok = false
+				break
+			}
+
+			var vars = make([]snmp.VarBind, len(options.Scalars)+len(options.Objects)+len(options.TableEntries))
 
 			for i, v := range scalarVars {
 				vars[i] = v
@@ -176,4 +267,8 @@ func (client *Client) GetScalars(oids []snmp.OID) ([]snmp.VarBind, error) {
 
 func (client *Client) WalkObjects(oids []snmp.OID, walkFunc WalkFunc) error {
 	return client.WalkWithOptions(WalkOptions{Objects: oids}, walkFunc)
+}
+
+func (client *Client) WalkTable(entryOids []snmp.OID, walkFunc WalkFunc) error {
+	return client.WalkWithOptions(WalkOptions{TableEntries: entryOids}, walkFunc)
 }

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -187,7 +187,7 @@ func TestWalkTableSparse(t *testing.T) {
 		transport.mockGetNextMulti("test", []snmp.OID{oid1.Extend(3), oid2.Extend(3)}, []snmp.VarBind{snmp.MakeVarBind(oid1, snmp.EndOfMibViewValue), snmp.MakeVarBind(oid2, snmp.EndOfMibViewValue)})
 
 		testWalk(t, client, walkTest{
-			options: WalkOptions{Objects: []snmp.OID{oid1, oid2}},
+			options: WalkOptions{TableEntries: []snmp.OID{oid1, oid2}},
 			results: [][]snmp.VarBind{
 				[]snmp.VarBind{varBinds1[0], varBinds2[0]},
 				[]snmp.VarBind{varBinds1[1], errBind},

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -65,7 +65,9 @@ func TestWalkScalarsOnly(t *testing.T) {
 		// nothing, because no entries
 		testWalk(t, client, walkTest{
 			options: WalkOptions{Scalars: []snmp.OID{oid}},
-			results: [][]snmp.VarBind{},
+			results: [][]snmp.VarBind{
+				[]snmp.VarBind{varBinds[0]},
+			},
 		})
 	})
 }

--- a/client/walk_test.go
+++ b/client/walk_test.go
@@ -6,41 +6,23 @@ import (
 	"testing"
 )
 
-type walkResult struct {
-	scalars []snmp.VarBind
-	entries []snmp.VarBind
-}
-
 type walkTest struct {
 	useBulk bool
-	scalars []snmp.OID
-	entries []snmp.OID
+	options WalkOptions
 
-	results []walkResult
+	results [][]snmp.VarBind
 }
 
 func testWalk(t *testing.T, client *Client, test walkTest) {
-	var results = []walkResult{}
-
-	for i, result := range test.results {
-		if result.scalars == nil {
-			result.scalars = []snmp.VarBind{}
-		}
-		if result.entries == nil {
-			result.entries = []snmp.VarBind{}
-		}
-
-		test.results[i] = result
-	}
-
+	var results = make([][]snmp.VarBind, 0)
 	client.options.NoBulk = !test.useBulk
 
-	if err := client.WalkWithScalars(test.scalars, test.entries, func(scalars []snmp.VarBind, entries []snmp.VarBind) error {
-		results = append(results, walkResult{scalars, entries})
+	if err := client.WalkWithOptions(test.options, func(vars []snmp.VarBind) error {
+		results = append(results, vars)
 
 		return nil
 	}); err != nil {
-		t.Fatalf("Walk(%v, %v): %v", test.scalars, test.entries, err)
+		t.Fatalf("Walk(%#v): %v", test.options, err)
 	}
 
 	assert.Equal(t, test.results, results)
@@ -62,10 +44,10 @@ func TestWalkTable(t *testing.T) {
 		transport.mockGetNext("test", ifName.Extend(2), varBinds[2])
 
 		testWalk(t, client, walkTest{
-			entries: []snmp.OID{ifName},
-			results: []walkResult{
-				{entries: []snmp.VarBind{varBinds[0]}},
-				{entries: []snmp.VarBind{varBinds[1]}},
+			options: WalkOptions{Objects: []snmp.OID{ifName}},
+			results: [][]snmp.VarBind{
+				[]snmp.VarBind{varBinds[0]},
+				[]snmp.VarBind{varBinds[1]},
 			},
 		})
 	})
@@ -82,8 +64,8 @@ func TestWalkScalarsOnly(t *testing.T) {
 
 		// nothing, because no entries
 		testWalk(t, client, walkTest{
-			scalars: []snmp.OID{oid},
-			results: []walkResult{},
+			options: WalkOptions{Scalars: []snmp.OID{oid}},
+			results: [][]snmp.VarBind{},
 		})
 	})
 }
@@ -91,9 +73,11 @@ func TestWalkScalarsOnly(t *testing.T) {
 func TestWalkEmpty(t *testing.T) {
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
 		testWalk(t, client, walkTest{
-			scalars: []snmp.OID{},
-			entries: []snmp.OID{},
-			results: []walkResult{},
+			options: WalkOptions{
+				Scalars: []snmp.OID{},
+				Objects: []snmp.OID{},
+			},
+			results: [][]snmp.VarBind{},
 		})
 	})
 }
@@ -116,11 +100,13 @@ func TestWalk(t *testing.T) {
 		transport.mockGetNextMulti("test", []snmp.OID{ifNumber, ifName.Extend(2)}, []snmp.VarBind{varBind, varBinds[2]})
 
 		testWalk(t, client, walkTest{
-			scalars: []snmp.OID{ifNumber},
-			entries: []snmp.OID{ifName},
-			results: []walkResult{
-				{scalars: []snmp.VarBind{varBind}, entries: []snmp.VarBind{varBinds[0]}},
-				{scalars: []snmp.VarBind{varBind}, entries: []snmp.VarBind{varBinds[1]}},
+			options: WalkOptions{
+				Scalars: []snmp.OID{ifNumber},
+				Objects: []snmp.OID{ifName},
+			},
+			results: [][]snmp.VarBind{
+				[]snmp.VarBind{varBind, varBinds[0]},
+				[]snmp.VarBind{varBind, varBinds[1]},
 			},
 		})
 	})
@@ -140,15 +126,16 @@ func TestWalkV2(t *testing.T) {
 		transport.mockGetNext("test", varBinds[1].OID(), varBinds[2])
 
 		testWalk(t, client, walkTest{
-			entries: []snmp.OID{oid},
-			results: []walkResult{
-				{entries: []snmp.VarBind{varBinds[0]}},
-				{entries: []snmp.VarBind{varBinds[1]}},
+			options: WalkOptions{Objects: []snmp.OID{oid}},
+			results: [][]snmp.VarBind{
+				[]snmp.VarBind{varBinds[0]},
+				[]snmp.VarBind{varBinds[1]},
 			},
 		})
 	})
 }
 
+// test walk of missing column
 func TestWalkTablePartial(t *testing.T) {
 	var oid1 = snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 1} // Q-BRIDGE-MIB::dot1qTpFdbAddress (not-accessible)
 	var oid2 = snmp.OID{1, 3, 6, 1, 2, 1, 17, 7, 1, 2, 2, 1, 2} // Q-BRIDGE-MIB::dot1qTpFdbPort
@@ -166,16 +153,16 @@ func TestWalkTablePartial(t *testing.T) {
 		transport.mockGetNextMulti("test", []snmp.OID{oid1, varBinds[1].OID()}, []snmp.VarBind{varBinds[0], varBinds[2]})
 
 		testWalk(t, client, walkTest{
-			entries: []snmp.OID{oid1, oid2},
-			results: []walkResult{
-				{entries: []snmp.VarBind{errBind, varBinds[0]}},
-				{entries: []snmp.VarBind{errBind, varBinds[1]}},
+			options: WalkOptions{Objects: []snmp.OID{oid1, oid2}},
+			results: [][]snmp.VarBind{
+				[]snmp.VarBind{errBind, varBinds[0]},
+				[]snmp.VarBind{errBind, varBinds[1]},
 			},
 		})
 	})
 }
 
-func TestWalkMany(t *testing.T) {
+func TestWalkSplit(t *testing.T) {
 	var oids = []snmp.OID{
 		snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 0},
 		snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 1},
@@ -219,9 +206,9 @@ func TestWalkMany(t *testing.T) {
 		})
 
 		testWalk(t, client, walkTest{
-			entries: oids,
-			results: []walkResult{
-				{entries: varBinds},
+			options: WalkOptions{Objects: oids},
+			results: [][]snmp.VarBind{
+				varBinds,
 			},
 		})
 	})
@@ -320,11 +307,13 @@ func TestWalkBulk(t *testing.T) {
 
 		testWalk(t, client, walkTest{
 			useBulk: true,
-			scalars: []snmp.OID{ifNumber},
-			entries: []snmp.OID{ifIndex, ifName},
-			results: []walkResult{
-				{scalars: []snmp.VarBind{numberVar}, entries: []snmp.VarBind{indexVars[0], nameVars[0]}},
-				{scalars: []snmp.VarBind{numberVar}, entries: []snmp.VarBind{indexVars[1], nameVars[1]}},
+			options: WalkOptions{
+				Scalars: []snmp.OID{ifNumber},
+				Objects: []snmp.OID{ifIndex, ifName},
+			},
+			results: [][]snmp.VarBind{
+				[]snmp.VarBind{numberVar, indexVars[0], nameVars[0]},
+				[]snmp.VarBind{numberVar, indexVars[1], nameVars[1]},
 			},
 		})
 	})
@@ -334,9 +323,11 @@ func TestWalkBulkEmpty(t *testing.T) {
 	withTestClient(t, "test", func(transport *testTransport, client *Client) {
 		testWalk(t, client, walkTest{
 			useBulk: true,
-			scalars: []snmp.OID{},
-			entries: []snmp.OID{},
-			results: []walkResult{},
+			options: WalkOptions{
+				Scalars: []snmp.OID{},
+				Objects: []snmp.OID{},
+			},
+			results: [][]snmp.VarBind{},
 		})
 	})
 }

--- a/cmd/snmpwalk/main.go
+++ b/cmd/snmpwalk/main.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 func snmpwalk(client *client.Client, oids ...snmp.OID) error {
-	return client.Walk(oids, func(varBinds []snmp.VarBind) error {
+	return client.WalkObjects(oids, func(varBinds []snmp.VarBind) error {
 		for _, varBind := range varBinds {
 			options.PrintVarBind(varBind)
 		}

--- a/mibs/client.go
+++ b/mibs/client.go
@@ -22,7 +22,7 @@ func (client Client) Probe(ids []ID) ([]bool, error) {
 		oids[i] = id.OID
 	}
 
-	if varBinds, err := client.WalkScalars(oids); err != nil {
+	if varBinds, err := client.GetScalars(oids); err != nil {
 		return probed, err
 	} else {
 		for i, varBind := range varBinds {
@@ -44,7 +44,7 @@ func (client Client) WalkObjects(objects []*Object, f func(*Object, IndexValues,
 		oids[i] = object.OID
 	}
 
-	return client.Walk(oids, func(varBinds []snmp.VarBind) error {
+	return client.Client.WalkObjects(oids, func(varBinds []snmp.VarBind) error {
 		for i, varBind := range varBinds {
 			var object = objects[i]
 			var walkErr error
@@ -69,7 +69,7 @@ func (client Client) WalkObjects(objects []*Object, f func(*Object, IndexValues,
 }
 
 func (client Client) WalkTable(table *Table, f func(IndexValues, EntryValues, error) error) error {
-	return client.Walk(table.EntryOIDs(), func(varBinds []snmp.VarBind) error {
+	return client.Client.WalkTable(table.EntryOIDs(), func(varBinds []snmp.VarBind) error {
 		indexValues, entryValues, err := table.Unpack(varBinds)
 
 		return f(indexValues, entryValues, err)


### PR DESCRIPTION
Fixes #18

Separate `client.WalkScalars()`, `client.WalkObjects()`, `client.WalkTable()` functions using different OID stepping functions. The new `WalkTable` chooses the minimum index per row, and only returns objects matching that index, and uses it for the next step.