### PR TITLE
Fix client requestID wrapping, randomize requestID pool

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,11 +2,13 @@ package client
 
 import (
 	"fmt"
+	"math"
+	"testing"
+	"time"
+
 	"github.com/qmsk/go-logging"
 	"github.com/qmsk/snmpbot/snmp"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func makeTestClient(t *testing.T, addr string) (*testTransport, *Engine, *Client) {
@@ -509,4 +511,63 @@ func TestGetRequestGetBulkOdd(t *testing.T) {
 			},
 		}, entryVarsList)
 	})
+}
+
+func testGetRequestID(t *testing.T, initRequestIDPool requestIDPool, requestID int) {
+	var oid = snmp.OID{1, 3, 6, 1, 2, 1, 1, 5, 0}
+	var value = int64(1)
+
+	withTestClient(t, "test", func(transport *testTransport, client *Client) {
+		transport.passRequestID = true
+
+		client.engine.requestIDPool = initRequestIDPool
+
+		transport.On("GetRequest", IO{
+			Addr: testAddr("test"),
+			Packet: snmp.Packet{
+				Version:   snmp.SNMPv2c,
+				Community: []byte("public"),
+			},
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetRequestType, RequestID: requestID},
+			PDU: snmp.GenericPDU{
+				VarBinds: []snmp.VarBind{
+					snmp.MakeVarBind(oid, nil),
+				},
+			},
+		}).Return(nil, IO{
+			Addr: testAddr("test"),
+			Packet: snmp.Packet{
+				Version:   snmp.SNMPv2c,
+				Community: []byte("public"),
+			},
+			PDUMeta: snmp.PDUMeta{PDUType: snmp.GetResponseType, RequestID: requestID},
+			PDU: snmp.GenericPDU{
+				VarBinds: []snmp.VarBind{
+					snmp.MakeVarBind(oid, 1),
+				},
+			},
+		})
+
+		if varBinds, err := client.Get(oid); err != nil {
+			t.Fatalf("Get(%v): %v", oid, err)
+		} else {
+			assertVarBind(t, varBinds, 0, oid, value)
+		}
+	})
+}
+
+func TestGetRequestID0(t *testing.T) {
+	testGetRequestID(t, 0, 1)
+}
+
+func TestGetRequestIDWrap(t *testing.T) {
+	testGetRequestID(t, math.MaxInt32-1, math.MaxInt32)
+}
+
+func TestGetRequestIDWrap0(t *testing.T) {
+	testGetRequestID(t, math.MaxInt32, 0)
+}
+
+func TestGetRequestIDWrap1(t *testing.T) {
+	testGetRequestID(t, math.MaxInt32+1, 1)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -79,7 +79,7 @@ func TestGetTimeout(t *testing.T) {
 		} else if timeoutErr, ok := err.(TimeoutError); !ok {
 			t.Errorf("Get(%v): %v", oid, err)
 		} else {
-			assert.EqualError(t, err, fmt.Sprintf("SNMP<testing> timeout for GetRequest<1.3.6.1.2.1.1.5.0>@test[1] after %v", timeoutErr.Duration))
+			assert.EqualError(t, err, fmt.Sprintf("SNMP<testing> timeout for GetRequest<1.3.6.1.2.1.1.5.0>@test[%d] after %v", timeoutErr.request.id, timeoutErr.Duration))
 		}
 	})
 }
@@ -146,7 +146,7 @@ func TestGetRecvWrongAddr(t *testing.T) {
 		} else if timeoutErr, ok := err.(TimeoutError); !ok {
 			t.Errorf("Get(%v): %v", oid, err)
 		} else {
-			assert.EqualError(t, err, fmt.Sprintf("SNMP<testing> timeout for GetRequest<1.3.6.1.2.1.1.5.0>@test[1] after %v", timeoutErr.Duration))
+			assert.EqualError(t, err, fmt.Sprintf("SNMP<testing> timeout for GetRequest<1.3.6.1.2.1.1.5.0>@test[%d] after %v", timeoutErr.request.id, timeoutErr.Duration))
 		}
 	})
 }
@@ -186,7 +186,7 @@ func TestGetRecvWrongCommunity(t *testing.T) {
 		} else if timeoutErr, ok := err.(TimeoutError); !ok {
 			t.Errorf("Get(%v): %v", oid, err)
 		} else {
-			assert.EqualError(t, err, fmt.Sprintf("SNMP<testing> timeout for GetRequest<1.3.6.1.2.1.1.5.0>@test[1] after %v", timeoutErr.Duration))
+			assert.EqualError(t, err, fmt.Sprintf("SNMP<testing> timeout for GetRequest<1.3.6.1.2.1.1.5.0>@test[%d] after %v", timeoutErr.request.id, timeoutErr.Duration))
 		}
 	})
 }

--- a/client/engine.go
+++ b/client/engine.go
@@ -3,10 +3,15 @@ package client
 import (
 	"fmt"
 	"github.com/qmsk/go-logging"
+	"math/rand"
 	"sync/atomic"
 )
 
 type requestIDPool uint32
+
+func randomizedRequestIDPool() requestIDPool {
+	return requestIDPool(rand.Uint32())
+}
 
 // Return next request ID between 0..214783647
 func (pool *requestIDPool) atomicNext() requestID {
@@ -29,7 +34,7 @@ func makeEngine(transport Transport) Engine {
 	return Engine{
 		transport: transport,
 
-		requestIDPool: 0, // TODO: randomize
+		requestIDPool: randomizedRequestIDPool(),
 		requests:      make(requestMap),
 		requestChan:   make(chan *Request),
 		timeoutChan:   make(chan ioKey),

--- a/client/engine.go
+++ b/client/engine.go
@@ -8,8 +8,9 @@ import (
 
 type requestIDPool uint32
 
+// Return next request ID between 0..214783647
 func (pool *requestIDPool) atomicNext() requestID {
-	return requestID(atomic.AddUint32((*uint32)(pool), 1))
+	return requestID(atomic.AddUint32((*uint32)(pool), 1) % requestIDWrapping)
 }
 
 func NewUDPEngine(udpOptions UDPOptions) (*Engine, error) {

--- a/client/request.go
+++ b/client/request.go
@@ -6,7 +6,13 @@ import (
 	"time"
 )
 
-type requestID uint32
+/*
+	PDU ::= SEQUENCE {
+        request-id INTEGER (-214783648..214783647),
+*/
+type requestID int32
+
+const requestIDWrapping = (1 << 31)
 
 type requestMap map[ioKey]*Request
 

--- a/client/transport_test.go
+++ b/client/transport_test.go
@@ -27,6 +27,8 @@ type testTransport struct {
 
 	recvChan      chan IO
 	recvErrorChan chan error
+
+	passRequestID bool
 }
 
 func (transport *testTransport) String() string {
@@ -40,8 +42,10 @@ func (transport *testTransport) Resolve(addr string) (net.Addr, error) {
 func (transport *testTransport) Send(io IO) error {
 	var requestID = io.RequestID
 
-	// override requestID to 0 for assert.Equal() comparison
-	io.RequestID = 0
+	if !transport.passRequestID {
+		// override requestID to 0 for assert.Equal() comparison
+		io.RequestID = 0
+	}
 
 	args := transport.MethodCalled(io.PDUType.String(), io)
 
@@ -49,7 +53,10 @@ func (transport *testTransport) Send(io IO) error {
 		// no response
 	} else {
 		recv := ret.(IO)
-		recv.RequestID = requestID
+
+		if !transport.passRequestID {
+			recv.RequestID = requestID
+		}
 
 		transport.recvChan <- recv
 	}


### PR DESCRIPTION
Fixes #26

* Wrap client engine requestID values from 214783647 -> 0
* Randomize client engine starting requestID pool