### PR TITLE
Add UnmarshalJSON function to api.Error

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -1,18 +1,28 @@
 package api
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 )
 
 type Error struct {
 	Error error
 }
 
+// Custom JSON Marshal function for error type
+// Formats errors to strings
 func (err Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(err.Error.Error())
 }
 
-func (err Error) UnmarshalJSON(data []byte) error {
-	return fmt.Errorf(string(data))
+// Custom JSON Unmarshal function for error type
+// error string back to Error
+func (err *Error) UnmarshalJSON(data []byte) error {
+	var errorMessage string
+	errors := json.Unmarshal(data, &errorMessage)
+	if errors != nil {
+		return errors
+	}
+	err.Error = fmt.Errorf(errorMessage)
+	return nil
 }

--- a/api/error.go
+++ b/api/error.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"encoding/json"
 )
 
@@ -10,4 +11,8 @@ type Error struct {
 
 func (err Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(err.Error.Error())
+}
+
+func (err Error) UnmarshalJSON(data []byte) error {
+	return fmt.Errorf(string(data))
 }

--- a/api/error_test.go
+++ b/api/error_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+type TestStruct struct {
+	Message Error `json:"error"`
+}
+
+func TestErrorJSONMarshal(t *testing.T) {
+	ts := TestStruct{Message: Error{fmt.Errorf("Test error")}}
+	var testData []byte
+	var err error
+	testData, err = json.Marshal(ts)
+
+	if err != nil {
+		t.Errorf("Failed to marshal Error")
+	}
+
+	if string(testData) != "{\"error\":\"Test error\"}" {
+		t.Errorf("Unexpected JSON marshalled string %s", string(testData))
+	}
+}
+
+func TestErrorJsonUnmarshal(t *testing.T) {
+	var testData []byte = []byte("{\"error\": \"Test error\"}")
+	var target TestStruct
+	err := json.Unmarshal(testData, &target)
+	if err != nil {
+		t.Errorf("Failed to unmarshal error")
+	}
+	if target.Message.Error.Error() != "Test error" {
+		t.Errorf("Error message not same as in JSON")
+	}
+}


### PR DESCRIPTION
It's useful to have UnmarshalJSON function when snmpbot is used as a library to unmarshal API messages back to Go structs.